### PR TITLE
XIVY-15945 make add content object dialog scrollable

### DIFF
--- a/packages/cms-editor/src/main/control/AddContentObject.css
+++ b/packages/cms-editor/src/main/control/AddContentObject.css
@@ -1,0 +1,7 @@
+.cms-editor-add-content-object-content {
+  max-height: 80vh;
+}
+
+.cms-editor-add-content-object-content-fields {
+  overflow: auto;
+}

--- a/packages/cms-editor/src/main/control/AddContentObject.tsx
+++ b/packages/cms-editor/src/main/control/AddContentObject.tsx
@@ -30,6 +30,7 @@ import { useClient } from '../../protocol/ClientContextProvider';
 import { genQueryKey, useQueryKeys } from '../../query/query-client';
 import { removeValue } from '../../utils/cms-utils';
 import { useKnownHotkeys } from '../../utils/hotkeys';
+import './AddContentObject.css';
 import { toLanguages } from './language-tool/language-utils';
 import { useValidateAddContentObject } from './use-validate-add-content-object';
 
@@ -118,12 +119,16 @@ export const AddContentObject = ({ selectRow }: AddContentObjectProps) => {
           <TooltipContent>{shortcut.label}</TooltipContent>
         </Tooltip>
       </TooltipProvider>
-      <DialogContent onCloseAutoFocus={e => e.preventDefault()}>
+      <DialogContent
+        onCloseAutoFocus={e => e.preventDefault()}
+        style={{ display: 'flex', flexDirection: 'column' }}
+        className='cms-editor-add-content-object-content'
+      >
         <DialogHeader>
           <DialogTitle>{t('dialog.addContentObject.title')}</DialogTitle>
         </DialogHeader>
         <DialogDescription>{t('dialog.addContentObject.description')}</DialogDescription>
-        <Flex direction='column' gap={3} ref={enter} tabIndex={-1}>
+        <Flex direction='column' gap={3} ref={enter} tabIndex={-1} className='cms-editor-add-content-object-content-fields'>
           <BasicField label={t('common.label.name')} message={nameMessage}>
             <Input value={name} onChange={event => setName(event.target.value)} disabled={isPending} />
           </BasicField>


### PR DESCRIPTION
The "Add Content Object" dialog needs to be scrollable for the case where a lot of default languages are defined.

![scrollable-add-content-object-dialog](https://github.com/user-attachments/assets/dcf000b9-5f99-442c-95c4-e939f52df191)
