### PR TITLE
XIVY-15945 remove missing default languages

### DIFF
--- a/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
@@ -121,14 +121,22 @@ export const LanguageTool = () => {
   });
 
   const save = () => {
-    setDefaultLanguageTags(defaultLanguages);
     const localesToDelete = locales.filter(locale => !languages.some(language => language.value === locale));
-    if (localesToDelete) {
+    if (localesToDelete.length !== 0) {
       deleteMutation.mutate({ context, locales: localesToDelete });
     }
     const localesToAdd = languages.map(language => language.value).filter(locale => !locales.includes(locale));
-    if (localesToAdd) {
-      addMutation.mutate({ context, locales: localesToAdd });
+    if (localesToAdd.length !== 0) {
+      addMutation.mutate(
+        { context, locales: localesToAdd },
+        {
+          onSuccess: () => {
+            setDefaultLanguageTags(defaultLanguages);
+          }
+        }
+      );
+    } else {
+      setDefaultLanguageTags(defaultLanguages);
     }
     setOpen(false);
   };

--- a/packages/cms-editor/src/use-languages.test.ts
+++ b/packages/cms-editor/src/use-languages.test.ts
@@ -1,6 +1,5 @@
 import type { Client, CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
-import { waitFor } from '@testing-library/react';
-import { act } from 'react';
+import { act, waitFor } from '@testing-library/react';
 import { customRenderHook } from './context/test-utils/test-utils';
 import { defaultLanguageTagsKey, useLanguages } from './use-languages';
 

--- a/packages/cms-editor/src/use-languages.test.ts
+++ b/packages/cms-editor/src/use-languages.test.ts
@@ -6,10 +6,11 @@ import { defaultLanguageTagsKey, useLanguages } from './use-languages';
 afterEach(() => localStorage.clear());
 
 test('default languages set via local storage', async () => {
-  localStorage.setItem(defaultLanguageTagsKey, '["en", "fr"]');
-  const view = renderLanguageHook('de', []);
-  expect(view.result.current.defaultLanguageTags).toEqual(['en', 'fr']);
+  localStorage.setItem(defaultLanguageTagsKey, '["de","en","fr"]');
+  const view = renderLanguageHook('de', ['en', 'fr', 'ja']);
+  await waitFor(() => expect(view.result.current.defaultLanguageTags).toEqual(['en', 'fr']));
   expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
+  expect(localStorage.getItem(defaultLanguageTagsKey)).toEqual('["en","fr"]');
 
   view.result.current.setDefaultLanguageTags(['ja']);
   view.rerender();

--- a/packages/cms-editor/src/use-languages.test.ts
+++ b/packages/cms-editor/src/use-languages.test.ts
@@ -1,5 +1,6 @@
 import type { Client, CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
 import { waitFor } from '@testing-library/react';
+import { act } from 'react';
 import { customRenderHook } from './context/test-utils/test-utils';
 import { defaultLanguageTagsKey, useLanguages } from './use-languages';
 
@@ -12,7 +13,7 @@ test('default languages set via local storage', async () => {
   expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
   expect(localStorage.getItem(defaultLanguageTagsKey)).toEqual('["en","fr"]');
 
-  view.result.current.setDefaultLanguageTags(['ja']);
+  act(() => view.result.current.setDefaultLanguageTags(['ja']));
   view.rerender();
   expect(view.result.current.defaultLanguageTags).toEqual(['ja']);
   expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');

--- a/packages/cms-editor/src/use-languages.ts
+++ b/packages/cms-editor/src/use-languages.ts
@@ -13,7 +13,7 @@ export const useLanguages = (context: CmsEditorDataContext) => {
   const [defaultLanguageTags, setDefaultLanguageTagsState] = useState(defaultLanguages(locales.data, clientLanguageTag));
   const setDefaultLanguageTags = (languageTags: Array<string>) => {
     setDefaultLanguageTagsState(languageTags);
-    localStorage.setItem(defaultLanguageTagsKey, JSON.stringify(languageTags));
+    setDefaultLanguageTagsLocalStorage(languageTags);
   };
   useEffect(() => setDefaultLanguageTagsState(defaultLanguages(locales.data, clientLanguageTag)), [locales.data, clientLanguageTag]);
 
@@ -21,11 +21,14 @@ export const useLanguages = (context: CmsEditorDataContext) => {
 };
 
 const defaultLanguages = (locales: Array<string>, clientLanguageTag: string): Array<string> => {
+  if (locales.length == 0) {
+    return [clientLanguageTag];
+  }
   const defaultLanguageTags = localStorage.getItem(defaultLanguageTagsKey);
   if (defaultLanguageTags) {
-    return JSON.parse(defaultLanguageTags);
+    return updateDefaultLanguageTags(JSON.parse(defaultLanguageTags), locales);
   }
-  if (locales.includes(clientLanguageTag) || locales.length === 0) {
+  if (locales.includes(clientLanguageTag)) {
     return [clientLanguageTag];
   }
   if (locales.includes('en')) {
@@ -33,3 +36,15 @@ const defaultLanguages = (locales: Array<string>, clientLanguageTag: string): Ar
   }
   return [locales[0]];
 };
+
+const updateDefaultLanguageTags = (defaultLanguageTags: Array<string>, locales: Array<string>) => {
+  if (defaultLanguageTags.every(languageTag => locales.includes(languageTag))) {
+    return defaultLanguageTags;
+  }
+  const defaultLanguages = defaultLanguageTags.filter(languageTag => locales.includes(languageTag));
+  setDefaultLanguageTagsLocalStorage(defaultLanguages);
+  return defaultLanguages;
+};
+
+const setDefaultLanguageTagsLocalStorage = (languageTags: Array<string>) =>
+  localStorage.setItem(defaultLanguageTagsKey, JSON.stringify(languageTags));


### PR DESCRIPTION
Previously, if you had a default language set but somehow removed the language from the CMS outside of the CMS Editor (e.g. by deleting the cms yaml file in a file explorer), the default language is still present but cannot be removed in a straightforward way. Now, whenever the default languages are computed, default languages set in the local storage that are not present in the CMS will be removed.