### PR TITLE
XIVY-15945 hide missing default languages

### DIFF
--- a/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
@@ -33,12 +33,13 @@ import { useAppContext } from '../../../context/AppContext';
 import { useClient } from '../../../protocol/ClientContextProvider';
 import { useMeta } from '../../../protocol/use-meta';
 import { genQueryKey } from '../../../query/query-client';
+import { getDefaultLanguageTagsLocalStorage } from '../../../use-languages';
 import { useKnownHotkeys } from '../../../utils/hotkeys';
 import { LanguageToolControl } from './LanguageToolControl';
 import { sortLanguages, toLanguages, type Language } from './language-utils';
 
 export const LanguageTool = () => {
-  const { context, defaultLanguageTags, setDefaultLanguageTags, languageDisplayName } = useAppContext();
+  const { context, setDefaultLanguageTags, languageDisplayName } = useAppContext();
   const { t } = useTranslation();
 
   const [open, setOpen] = useState(false);
@@ -49,7 +50,15 @@ export const LanguageTool = () => {
     }
   };
 
-  const [defaultLanguages, setDefaultLanguages] = useState(defaultLanguageTags);
+  const initialDefaultLanguages = () => {
+    const defaultLanguageTags = getDefaultLanguageTagsLocalStorage();
+    if (!defaultLanguageTags) {
+      return [];
+    }
+    return defaultLanguageTags;
+  };
+
+  const [defaultLanguages, setDefaultLanguages] = useState(initialDefaultLanguages());
   const [languages, setLanguages] = useState<Array<Language>>([]);
 
   const addLanguage = (language: Language) => setLanguages(languages => sortLanguages([...languages, language]));
@@ -57,13 +66,12 @@ export const LanguageTool = () => {
   const deleteSelectedLanguage = () => {
     const { newData } = deleteFirstSelectedRow(table, languages);
     setLanguages(newData);
-    removeDefaultLanguage(table.getSelectedRowModel().flatRows[0].original.value);
   };
 
   const locales = useMeta('meta/locales', context, []).data;
 
   const initializeDialog = () => {
-    setDefaultLanguages(defaultLanguageTags);
+    setDefaultLanguages(initialDefaultLanguages());
     setLanguages(toLanguages(locales, languageDisplayName));
     table.resetRowSelection();
   };

--- a/packages/cms-editor/src/use-languages.test.ts
+++ b/packages/cms-editor/src/use-languages.test.ts
@@ -1,7 +1,7 @@
 import type { Client, CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
 import { act, waitFor } from '@testing-library/react';
 import { customRenderHook } from './context/test-utils/test-utils';
-import { defaultLanguageTagsKey, useLanguages } from './use-languages';
+import { defaultLanguageTagsKey, getDefaultLanguageTagsLocalStorage, useLanguages } from './use-languages';
 
 afterEach(() => localStorage.clear());
 
@@ -10,27 +10,27 @@ test('default languages set via local storage', async () => {
   const view = renderLanguageHook('de', ['en', 'fr', 'ja']);
   await waitFor(() => expect(view.result.current.defaultLanguageTags).toEqual(['en', 'fr']));
   expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-  expect(localStorage.getItem(defaultLanguageTagsKey)).toEqual('["en","fr"]');
+  expect(getDefaultLanguageTagsLocalStorage()).toEqual(['de', 'en', 'fr']);
 
   act(() => view.result.current.setDefaultLanguageTags(['ja']));
   view.rerender();
   expect(view.result.current.defaultLanguageTags).toEqual(['ja']);
   expect(view.result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-  expect(localStorage.getItem(defaultLanguageTagsKey)).toEqual('["ja"]');
+  expect(getDefaultLanguageTagsLocalStorage()).toEqual(['ja']);
 });
 
 test('default languages not set via local storage', async () => {
   let result = renderLanguageHook('de', []).result;
   expect(result.current.defaultLanguageTags).toEqual([]);
   expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-  expect(localStorage.getItem(defaultLanguageTagsKey)).toBeNull();
+  expect(getDefaultLanguageTagsLocalStorage()).toBeUndefined();
 
   result = renderLanguageHook('de', ['ja', 'en']).result;
   await waitFor(() => {
     expect(result.current.defaultLanguageTags).toEqual(['en']);
   });
   expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-  expect(localStorage.getItem(defaultLanguageTagsKey)).toEqual('["en"]');
+  expect(getDefaultLanguageTagsLocalStorage()).toEqual(['en']);
 
   localStorage.removeItem(defaultLanguageTagsKey);
   result = renderLanguageHook('de', ['ja', 'fr']).result;
@@ -38,7 +38,7 @@ test('default languages not set via local storage', async () => {
     expect(result.current.defaultLanguageTags).toEqual(['ja']);
   });
   expect(result.current.languageDisplayName.resolvedOptions().locale).toEqual('de');
-  expect(localStorage.getItem(defaultLanguageTagsKey)).toEqual('["ja"]');
+  expect(getDefaultLanguageTagsLocalStorage()).toEqual(['ja']);
 });
 
 const renderLanguageHook = (clientLanguage: string, locales: Array<string>) => {

--- a/packages/cms-editor/src/use-languages.ts
+++ b/packages/cms-editor/src/use-languages.ts
@@ -24,9 +24,9 @@ const defaultLanguages = (locales: Array<string>, clientLanguageTag: string): Ar
   if (locales.length == 0) {
     return [];
   }
-  const defaultLanguageTags = localStorage.getItem(defaultLanguageTagsKey);
+  const defaultLanguageTags = getDefaultLanguageTagsLocalStorage();
   if (defaultLanguageTags) {
-    return updateDefaultLanguageTags(JSON.parse(defaultLanguageTags), locales);
+    return defaultLanguageTags.filter(languageTag => locales.includes(languageTag));
   }
   const defaultLanguages: Array<string> = [];
   if (locales.includes(clientLanguageTag)) {
@@ -40,13 +40,12 @@ const defaultLanguages = (locales: Array<string>, clientLanguageTag: string): Ar
   return defaultLanguages;
 };
 
-const updateDefaultLanguageTags = (defaultLanguageTags: Array<string>, locales: Array<string>) => {
-  if (defaultLanguageTags.every(languageTag => locales.includes(languageTag))) {
-    return defaultLanguageTags;
+export const getDefaultLanguageTagsLocalStorage = (): Array<string> | undefined => {
+  const defaultLanguageTags = localStorage.getItem(defaultLanguageTagsKey);
+  if (!defaultLanguageTags) {
+    return undefined;
   }
-  const defaultLanguages = defaultLanguageTags.filter(languageTag => locales.includes(languageTag));
-  setDefaultLanguageTagsLocalStorage(defaultLanguages);
-  return defaultLanguages;
+  return JSON.parse(defaultLanguageTags);
 };
 
 const setDefaultLanguageTagsLocalStorage = (languageTags: Array<string>) =>


### PR DESCRIPTION
Do not remove default languages that are missing from the CMS from the local storage.
Instead, simply filter them out.
The only way to change the default languages is by explicitly checking/unchecking the checkbox in the language tool.
Any other action like adding and deleting languages or opening a CMS with other languages present will not affect the default languages saved in the local storage.
