### PR TITLE
XIVY-15945 handle no default languages in add content object dialog

### DIFF
--- a/packages/cms-editor/src/main/control/AddContentObject.test.ts
+++ b/packages/cms-editor/src/main/control/AddContentObject.test.ts
@@ -1,11 +1,33 @@
-import type { ContentObject } from '@axonivy/cms-editor-protocol';
-import { initialNamespace, namespaceOptions } from './AddContentObject';
+import type { Client, ContentObject } from '@axonivy/cms-editor-protocol';
+import { waitFor } from '@testing-library/react';
+import { customRenderHook } from '../../context/test-utils/test-utils';
+import { initialNamespace, namespaceOptions, useLanguageTags } from './AddContentObject';
 
 test('initialNamespace', () => {
   const contentObjects = [{ uri: '/contentObject' }, { uri: '/folder/deep/contentObject' }] as Array<ContentObject>;
   expect(initialNamespace(contentObjects, undefined)).toEqual('');
   expect(initialNamespace(contentObjects, 0)).toEqual('');
   expect(initialNamespace(contentObjects, 1)).toEqual('/folder/deep');
+});
+
+test('useLanguageTags', async () => {
+  let result = renderLanguageTagsHook([], []).result;
+  expect(result.current.languageTags).toEqual([]);
+  expect(result.current.languageTagsMessage).toBeUndefined();
+
+  result = renderLanguageTagsHook(['de', 'en'], []).result;
+  await waitFor(() => {
+    expect(result.current.languageTags).toEqual(['de']);
+  });
+  expect(result.current.languageTagsMessage).toBeDefined();
+  expect(result.current.languageTagsMessage?.message).toBeDefined();
+  expect(result.current.languageTagsMessage?.variant).toEqual('info');
+
+  result = renderLanguageTagsHook([], ['de', 'en']).result;
+  await waitFor(() => {
+    expect(result.current.languageTags).toEqual(['de', 'en']);
+  });
+  expect(result.current.languageTagsMessage).toBeUndefined();
 });
 
 test('namespaceOptions', () => {
@@ -21,3 +43,21 @@ test('namespaceOptions', () => {
     ] as Array<ContentObject>)
   ).toEqual([{ value: '' }, { value: '/c' }, { value: '/c/c' }, { value: '/d' }]);
 });
+
+const renderLanguageTagsHook = (locales: Array<string>, defaultLanguageTags: Array<string>) => {
+  return customRenderHook(() => useLanguageTags(), {
+    wrapperProps: { clientContext: { client: new TestClient(locales) }, appContext: { defaultLanguageTags } }
+  });
+};
+
+class TestClient implements Partial<Client> {
+  private readonly locales: Array<string>;
+
+  constructor(locales: Array<string>) {
+    this.locales = locales;
+  }
+
+  meta(): Promise<Array<string>> {
+    return Promise.resolve(this.locales);
+  }
+}

--- a/packages/cms-editor/src/translation/cms-editor/de.json
+++ b/packages/cms-editor/src/translation/cms-editor/de.json
@@ -25,6 +25,7 @@
       "create": "Inhaltsobjekt erstellen",
       "createTooltip": "Halte {{modifier}} um ein weiteres Inhaltsobjekt zu erstellen.",
       "description": "Wählen Sie den Namen, den Namensbereich und die Werte des Inhaltsobjekts, das Sie hinzufügen möchten.",
+      "noDefaultLanguages": "Es sind keine Sprachen im Sprachwerkzeug markiert, die angezeigt werden sollen. Dies ist die erste gefundene Sprache.",
       "title": "Inhaltsobjekt hinzufügen"
     },
     "languageTool": {

--- a/packages/cms-editor/src/translation/cms-editor/en.json
+++ b/packages/cms-editor/src/translation/cms-editor/en.json
@@ -25,6 +25,7 @@
       "create": "Create Content Object",
       "createTooltip": "Hold {{modifier}} to add an additional Content Object.",
       "description": "Choose the name, namespace, and values of the Content Object you want to add.",
+      "noDefaultLanguages": "No languages are checked to be displayed in the Language Tool. This is the first language found.",
       "title": "Add Content Object"
     },
     "languageTool": {

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -31,13 +31,17 @@ test('default values', async () => {
 });
 
 test('show fields for values of default languages', async ({ page }) => {
-  editor = await CmsEditor.openMock(page, { parameters: { lng: 'ja' } });
+  editor = await CmsEditor.openMock(page, { parameters: { lng: 'en' }, defaultLanguages: [] });
   await editor.page.keyboard.press('a');
-  await expect(editor.main.control.add.value('英語').locator).toBeVisible();
+  await expect(editor.main.control.add.value('English').locator).toBeVisible();
+  await (
+    await editor.main.control.add.value('English').textbox.message()
+  ).expectToBeInfo('No languages are checked to be displayed in the Language Tool. This is the first language found.');
 
   editor = await CmsEditor.openMock(page, { parameters: { lng: 'en' }, defaultLanguages: ['de'] });
   await editor.page.keyboard.press('a');
   await expect(editor.main.control.add.value('German').locator).toBeVisible();
+  await expect((await editor.main.control.add.value('German').textbox.message()).locator).toBeHidden();
 
   editor = await CmsEditor.openMock(page, { parameters: { lng: 'de' }, defaultLanguages: ['en', 'de'] });
   await editor.page.keyboard.press('a');


### PR DESCRIPTION
If no default languages are defined, the "Add Content Object" dialog takes the first language of the CMS to display a field for its value.
This is necessary because it is not possible to create a Content Object without defining at least one value.
This circumstance is conveyed to the user via a message in the "Add Content Object" dialog.
