### PR TITLE
XIVY-15945 fix not present default languages appearing

### DIFF
--- a/packages/cms-editor/src/use-languages.ts
+++ b/packages/cms-editor/src/use-languages.ts
@@ -12,7 +12,7 @@ export const useLanguages = (context: CmsEditorDataContext) => {
   const locales = useMeta('meta/locales', context, []);
   const [defaultLanguageTags, setDefaultLanguageTagsState] = useState(defaultLanguages(locales.data, clientLanguageTag));
   const setDefaultLanguageTags = (languageTags: Array<string>) => {
-    setDefaultLanguageTagsState(languageTags);
+    setDefaultLanguageTagsState(filterNotPresentDefaultLanugageTags(languageTags, locales.data));
     setDefaultLanguageTagsLocalStorage(languageTags);
   };
   useEffect(() => setDefaultLanguageTagsState(defaultLanguages(locales.data, clientLanguageTag)), [locales.data, clientLanguageTag]);
@@ -26,7 +26,7 @@ const defaultLanguages = (locales: Array<string>, clientLanguageTag: string): Ar
   }
   const defaultLanguageTags = getDefaultLanguageTagsLocalStorage();
   if (defaultLanguageTags) {
-    return defaultLanguageTags.filter(languageTag => locales.includes(languageTag));
+    return filterNotPresentDefaultLanugageTags(defaultLanguageTags, locales);
   }
   const defaultLanguages: Array<string> = [];
   if (locales.includes(clientLanguageTag)) {
@@ -47,6 +47,9 @@ export const getDefaultLanguageTagsLocalStorage = (): Array<string> | undefined 
   }
   return JSON.parse(defaultLanguageTags);
 };
+
+const filterNotPresentDefaultLanugageTags = (defaultLanguageTags: Array<string>, locales: Array<string>) =>
+  defaultLanguageTags.filter(languageTag => locales.includes(languageTag));
 
 const setDefaultLanguageTagsLocalStorage = (languageTags: Array<string>) =>
   localStorage.setItem(defaultLanguageTagsKey, JSON.stringify(languageTags));

--- a/playwright/tests/integration/mock/language-tool.spec.ts
+++ b/playwright/tests/integration/mock/language-tool.spec.ts
@@ -9,7 +9,8 @@ test.beforeEach(async ({ page }) => {
 });
 
 describe('default languages', () => {
-  test('add and remove', async () => {
+  test('add and remove', async ({ page }) => {
+    editor = await CmsEditor.openMock(page, { defaultLanguages: ['en', 'fr'] });
     const languageTool = editor.main.control.languageTool;
     const table = editor.main.table;
 


### PR DESCRIPTION
After saving the Language Tool, default languages that are not present in the Language Tool appeared in the table because they were not being filtered when setting the state.
