### PR TITLE
XIVY-15945 fix: update main table on language deletion

### DIFF
--- a/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
@@ -31,7 +31,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../../../context/AppContext';
 import { useClient } from '../../../protocol/ClientContextProvider';
 import { useMeta } from '../../../protocol/use-meta';
-import { genQueryKey } from '../../../query/query-client';
+import { genQueryKey, useQueryKeys } from '../../../query/query-client';
 import { getDefaultLanguageTagsLocalStorage } from '../../../use-languages';
 import { useKnownHotkeys } from '../../../utils/hotkeys';
 import { sortLanguages, toLanguages, type Language } from './language-utils';
@@ -39,7 +39,7 @@ import './LanguageTool.css';
 import { LanguageToolControl } from './LanguageToolControl';
 
 export const LanguageTool = () => {
-  const { context, setDefaultLanguageTags, languageDisplayName } = useAppContext();
+  const { context, defaultLanguageTags, setDefaultLanguageTags, languageDisplayName } = useAppContext();
   const { t } = useTranslation();
 
   const [open, setOpen] = useState(false);
@@ -109,6 +109,7 @@ export const LanguageTool = () => {
 
   const client = useClient();
   const queryClient = useQueryClient();
+  const { dataKey } = useQueryKeys();
 
   const addMutation = useMutation({
     mutationFn: async (args: CmsAddLocalesArgs) => {
@@ -125,6 +126,11 @@ export const LanguageTool = () => {
         locales?.filter(locale => !args.locales.includes(locale))
       );
       client.removeLocales({ context, locales: args.locales });
+    },
+    onSuccess: () => {
+      if (JSON.stringify(initialDefaultLanguages().sort()) === JSON.stringify(defaultLanguages.sort())) {
+        queryClient.invalidateQueries({ queryKey: dataKey({ context, languageTags: defaultLanguageTags }) });
+      }
     }
   });
 
@@ -135,14 +141,7 @@ export const LanguageTool = () => {
     }
     const localesToAdd = languages.map(language => language.value).filter(locale => !locales.includes(locale));
     if (localesToAdd.length !== 0) {
-      addMutation.mutate(
-        { context, locales: localesToAdd },
-        {
-          onSuccess: () => {
-            setDefaultLanguageTags(defaultLanguages);
-          }
-        }
-      );
+      addMutation.mutate({ context, locales: localesToAdd }, { onSuccess: () => setDefaultLanguageTags(defaultLanguages) });
     } else {
       setDefaultLanguageTags(defaultLanguages);
     }

--- a/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
@@ -3,6 +3,7 @@ import {
   BasicCheckbox,
   BasicField,
   Button,
+  deepEqual,
   deleteFirstSelectedRow,
   Dialog,
   DialogContent,
@@ -128,7 +129,7 @@ export const LanguageTool = () => {
       client.removeLocales({ context, locales: args.locales });
     },
     onSuccess: () => {
-      if (JSON.stringify(initialDefaultLanguages().sort()) === JSON.stringify(defaultLanguages.sort())) {
+      if (deepEqual(initialDefaultLanguages().sort(), defaultLanguages.sort())) {
         queryClient.invalidateQueries({ queryKey: dataKey({ context, languageTags: defaultLanguageTags }) });
       }
     }

--- a/playwright/tests/integration/mock/language-tool.spec.ts
+++ b/playwright/tests/integration/mock/language-tool.spec.ts
@@ -118,6 +118,23 @@ describe('languages', () => {
     await expect(editor.main.table.headers).toHaveCount(1);
   });
 
+  test('remove deleted content objects after removing language', async () => {
+    const languageTool = editor.main.control.languageTool;
+
+    await editor.main.table.row(0).locator.click();
+    await expect(editor.main.table.row(0).column(0).value(0)).toHaveText('/Dialogs/agileBPM/define_WF/AddTask');
+    await expect(editor.detail.uri.locator).toHaveValue('/Dialogs/agileBPM/define_WF/AddTask');
+
+    await editor.detail.value('English').delete.click();
+    await languageTool.trigger.click();
+    await languageTool.languages.row(1).locator.click();
+    await languageTool.delete.click();
+    await languageTool.save.click();
+    await editor.main.table.row(0).expectToBeSelected();
+    await expect(editor.main.table.row(0).column(0).value(0)).toHaveText('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks');
+    await expect(editor.detail.uri.locator).toHaveValue('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks');
+  });
+
   test('keyboard support', async () => {
     const languageTool = editor.main.control.languageTool;
     const keyboard = editor.page.keyboard;


### PR DESCRIPTION
When languages are deleted, Content Objects that have no values left because the respective languages have been deleted will be deleted as well.
To make the main table reflect this change, the data query is invalidated if the default languages do not change.
In the case where the default languages do change, this already works, as the table gets rerendered because the columns change.
