### PR TITLE
XIVY-16623 add confirmation dialog when deleting languages with values

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -3,6 +3,7 @@ import type {
   Client,
   CmsActionArgs,
   CmsAddLocalesArgs,
+  CmsCountLocaleValuesArgs,
   CmsCreateArgs,
   CmsData,
   CmsDataObject,
@@ -77,16 +78,32 @@ export class CmsClientMock implements Client {
     values: Object.fromEntries(Object.entries(co.values).filter(entry => !locales.includes(entry[0])))
   });
 
-  meta<TMeta extends keyof MetaRequestTypes>(path: TMeta): Promise<MetaRequestTypes[TMeta][1]> {
+  meta<TMeta extends keyof MetaRequestTypes>(path: TMeta, args: MetaRequestTypes[TMeta][0]): Promise<MetaRequestTypes[TMeta][1]> {
     switch (path) {
       case 'meta/supportedLocales':
         return Promise.resolve(supportedLocales);
       case 'meta/locales':
         return Promise.resolve(this.localesData);
+      case 'meta/countLocaleValues':
+        return Promise.resolve(this.countLocaleValues((args as CmsCountLocaleValuesArgs).locales));
       default:
         throw Error('meta path not implemented');
     }
   }
+
+  private countLocaleValues = (locales: Array<string>) => {
+    return this.cmsData.data.reduce(
+      (localeValuesAmount, co) => {
+        locales.forEach(locale => {
+          if (co.values[locale] !== undefined) {
+            localeValuesAmount[locale] = ++localeValuesAmount[locale];
+          }
+        });
+        return localeValuesAmount;
+      },
+      Object.fromEntries(locales.map(locale => [locale, 0]))
+    );
+  };
 
   action(action: CmsActionArgs): void {
     console.log(`Action: ${JSON.stringify(action)}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "@axonivy/jsonrpc": "~13.1.0-next.674",
         "@axonivy/ui-components": "~13.1.0-next.674",
         "@axonivy/ui-icons": "~13.1.0-next.674",
-        "@tanstack/react-query": "^5.75.5",
-        "@tanstack/react-query-devtools": "^5.75.5",
+        "@tanstack/react-query": "^5.64",
+        "@tanstack/react-query-devtools": "^5.64",
         "i18next": "^25.0.0",
         "i18next-browser-languagedetector": "^8.0.4",
         "react": "^19.0.0",
@@ -44,10 +44,10 @@
         "react-i18next": "^15.4.1"
       },
       "devDependencies": {
-        "@types/react": "^19.1.3",
+        "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
-        "vite": "^6.3.5"
+        "vite": "^6.0.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -16398,12 +16398,12 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@axonivy/cms-editor-protocol": "~13.1.0-next",
-        "@tanstack/react-virtual": "^3.13.8"
+        "@tanstack/react-virtual": "^3.12.0"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "6.6.3",
         "@testing-library/react": "^16.2.0",
-        "@types/react": "^19.1.3",
+        "@types/react": "^19.0.7",
         "@vanilla-extract/recipes": "^0.5.5",
         "@vitejs/plugin-react": "^4.3.4",
         "i18next-parser": "^9.3.0",
@@ -16411,7 +16411,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "vite-plugin-dts": "^4.5.0",
-        "vitest": "^3.1.3"
+        "vitest": "^3.0.3"
       },
       "peerDependencies": {
         "@axonivy/jsonrpc": "~13.1.0-next",

--- a/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
@@ -38,6 +38,7 @@ import { useKnownHotkeys } from '../../../utils/hotkeys';
 import { sortLanguages, toLanguages, type Language } from './language-utils';
 import './LanguageTool.css';
 import { LanguageToolControl } from './LanguageToolControl';
+import { LanguageToolSaveConfirmation } from './LanguageToolSaveConfirmation';
 
 export const LanguageTool = () => {
   const { context, defaultLanguageTags, setDefaultLanguageTags, languageDisplayName } = useAppContext();
@@ -135,8 +136,7 @@ export const LanguageTool = () => {
     }
   });
 
-  const save = () => {
-    const localesToDelete = locales.filter(locale => !languages.some(language => language.value === locale));
+  const save = (localesToDelete: Array<string>) => {
     if (localesToDelete.length !== 0) {
       deleteMutation.mutate({ context, locales: localesToDelete });
     }
@@ -152,7 +152,6 @@ export const LanguageTool = () => {
   const hotkeys = useKnownHotkeys();
   useHotkeys(hotkeys.languageTool.hotkey, () => onOpenChange(true), { scopes: ['global'], keyup: true, enabled: !open });
   const deleteRef = useHotkeys(hotkeys.deleteLanguage.hotkey, () => deleteSelectedLanguage(), { scopes: ['global'] });
-  const enter = useHotkeys(['Enter'], () => save(), { scopes: ['global'], enabled: open, enableOnFormTags: true });
 
   const onKeyDown = (event: KeyboardEvent<HTMLTableElement>) => {
     if (event.code === 'Space') {
@@ -176,7 +175,6 @@ export const LanguageTool = () => {
         </Tooltip>
       </TooltipProvider>
       <DialogContent
-        ref={enter}
         onClick={() => table.resetRowSelection()}
         style={{ display: 'flex', flexDirection: 'column' }}
         className='cms-editor-language-tool-content'
@@ -210,9 +208,10 @@ export const LanguageTool = () => {
           </Table>
         </BasicField>
         <DialogFooter>
-          <Button variant='primary' size='large' aria-label={t('common.label.save')} onClick={save}>
-            {t('common.label.save')}
-          </Button>
+          <LanguageToolSaveConfirmation
+            localesToDelete={locales.filter(locale => !languages.some(language => language.value === locale))}
+            save={save}
+          />
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.css
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.css
@@ -1,0 +1,7 @@
+.cms-editor-language-tool-save-confirmation-content {
+  max-height: 80vh;
+}
+
+.cms-editor-language-tool-save-confirmation-language-values {
+  overflow: auto;
+}

--- a/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.tsx
@@ -77,7 +77,7 @@ export const LanguageToolSaveConfirmation = ({ localesToDelete, save }: Language
               aria-label={t('common.label.cancel')}
               // workaround since prop `autoFocus` is broken in dialogs (https://github.com/facebook/react/issues/23301)
               ref={button => {
-                setTimeout(() => button?.focus(), 10);
+                setTimeout(() => button?.focus(), 0);
               }}
             >
               {t('common.label.cancel')}

--- a/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.tsx
@@ -1,0 +1,90 @@
+import {
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Flex,
+  useHotkeys
+} from '@axonivy/ui-components';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useAppContext } from '../../../context/AppContext';
+import { useMeta } from '../../../protocol/use-meta';
+import './LanguageToolSaveConfirmation.css';
+
+type LanguageToolSaveConfirmationProps = {
+  localesToDelete: Array<string>;
+  save: (localesToDelete: Array<string>) => void;
+};
+
+export const LanguageToolSaveConfirmation = ({ localesToDelete, save }: LanguageToolSaveConfirmationProps) => {
+  const { context, languageDisplayName } = useAppContext();
+  const { t } = useTranslation();
+
+  const [open, setOpen] = useState(false);
+
+  const amountOfValuesToDelete = useMeta('meta/countLocaleValues', { context, locales: localesToDelete }, {}).data;
+  const onOpenChange = (open: boolean) => {
+    if (open && Object.values(amountOfValuesToDelete).every(value => value === 0)) {
+      setOpen(false);
+      save(localesToDelete);
+    } else {
+      setOpen(open);
+    }
+  };
+
+  useHotkeys(['Enter'], () => onOpenChange(true), { scopes: ['global'], keyup: true, enableOnFormTags: true });
+
+  const languageValuesDisplayString = (languageTag: string, amount: number) => {
+    const valueDisplayString = amount === 1 ? t('common.label.value') : t('common.label.values');
+    return `${languageDisplayName.of(languageTag)}: ${amount} ${valueDisplayString}`;
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant='primary' size='large' aria-label={t('common.label.save')}>
+          {t('common.label.save')}
+        </Button>
+      </DialogTrigger>
+      <DialogContent style={{ display: 'flex', flexDirection: 'column' }} className='cms-editor-language-tool-save-confirmation-content'>
+        <DialogHeader>
+          <DialogTitle>{t('dialog.languageTool.saveConfirmation.title')}</DialogTitle>
+        </DialogHeader>
+        <DialogDescription>{t('dialog.languageTool.saveConfirmation.description')}</DialogDescription>
+        <Flex direction='column' gap={1} className='cms-editor-language-tool-save-confirmation-language-values'>
+          {Object.entries(amountOfValuesToDelete)
+            .filter(([, amount]) => amount > 0)
+            .map(([languageTag, amount]) => (
+              <span key={languageTag}>{languageValuesDisplayString(languageTag, amount)}</span>
+            ))}
+        </Flex>
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant='primary' size='large' aria-label={t('common.label.save')} onClick={() => save(localesToDelete)}>
+              {t('common.label.save')}
+            </Button>
+          </DialogClose>
+          <DialogClose asChild>
+            <Button
+              variant='outline'
+              size='large'
+              aria-label={t('common.label.cancel')}
+              // workaround since prop `autoFocus` is broken in dialogs (https://github.com/facebook/react/issues/23301)
+              ref={button => {
+                setTimeout(() => button?.focus(), 10);
+              }}
+            >
+              {t('common.label.cancel')}
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/packages/cms-editor/src/translation/cms-editor/de.json
+++ b/packages/cms-editor/src/translation/cms-editor/de.json
@@ -17,7 +17,9 @@
       "save": "Speichern",
       "search": "Suchen",
       "settings": "Einstellungen",
-      "theme": "Thema"
+      "theme": "Thema",
+      "value": "Wert",
+      "values": "Werte"
     }
   },
   "dialog": {
@@ -35,6 +37,10 @@
         "addLanguage": "Sprache hinzufügen",
         "description": "Wählen Sie die Sprache aus, die Sie dem CMS hinzufügen möchten.",
         "title": "Sprachenübersicht"
+      },
+      "saveConfirmation": {
+        "description": "Speichern löscht die folgenden Sprachen und alle ihre Werte. Bist du sicher?",
+        "title": "Speichern bestätigen"
       },
       "title": "Sprachwerkzeug"
     }

--- a/packages/cms-editor/src/translation/cms-editor/en.json
+++ b/packages/cms-editor/src/translation/cms-editor/en.json
@@ -17,7 +17,9 @@
       "save": "Save",
       "search": "Search",
       "settings": "Settings",
-      "theme": "Theme"
+      "theme": "Theme",
+      "value": "value",
+      "values": "values"
     }
   },
   "dialog": {
@@ -35,6 +37,10 @@
         "addLanguage": "Add Language",
         "description": "Select the language you want to add to the CMS.",
         "title": "Language Browser"
+      },
+      "saveConfirmation": {
+        "description": "Saving will delete the following languages and all their values. Are you sure?",
+        "title": "Confirm Save"
       },
       "title": "Language Tool"
     }

--- a/packages/protocol/src/editor.ts
+++ b/packages/protocol/src/editor.ts
@@ -11,7 +11,7 @@ export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
 export interface CMS {
   cmsActionArgs: CmsActionArgs;
   cmsAddLocalesArgs: CmsAddLocalesArgs;
-  cmsCountLocaleValueArgs: CmsCountLocaleValueArgs;
+  cmsCountLocaleValuesArgs: CmsCountLocaleValuesArgs;
   cmsCreateArgs: CmsCreateArgs;
   cmsData: CmsData;
   cmsDataArgs: CmsDataArgs;
@@ -22,7 +22,7 @@ export interface CMS {
   cmsReadArgs: CmsReadArgs;
   cmsRemoveLocalesArgs: CmsRemoveLocalesArgs;
   cmsUpdateValueArgs: CmsUpdateValueArgs;
-  long: number;
+  long: MapStringLong;
   string: string[];
   void: Void;
   [k: string]: unknown;
@@ -41,9 +41,9 @@ export interface CmsAddLocalesArgs {
   context: CmsEditorDataContext;
   locales: string[];
 }
-export interface CmsCountLocaleValueArgs {
+export interface CmsCountLocaleValuesArgs {
   context: CmsEditorDataContext;
-  locale: string;
+  locales: string[];
 }
 export interface CmsCreateArgs {
   contentObject: CmsDataObject;
@@ -94,5 +94,8 @@ export interface CmsUpdateValueObject {
   languageTag: string;
   uri: string;
   value: string;
+}
+export interface MapStringLong {
+  [k: string]: number;
 }
 export interface Void {}

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -1,6 +1,7 @@
 import type {
   CmsActionArgs,
   CmsAddLocalesArgs,
+  CmsCountLocaleValuesArgs,
   CmsCreateArgs,
   CmsData,
   CmsDataArgs,
@@ -11,6 +12,7 @@ import type {
   CmsReadArgs,
   CmsRemoveLocalesArgs,
   CmsUpdateValueArgs,
+  MapStringLong,
   Void
 } from './editor';
 
@@ -38,6 +40,7 @@ export interface ClientContext {
 export interface MetaRequestTypes {
   'meta/supportedLocales': [null, Array<string>];
   'meta/locales': [CmsEditorDataContext, Array<string>];
+  'meta/countLocaleValues': [CmsCountLocaleValuesArgs, MapStringLong];
 }
 
 export interface RequestTypes extends MetaRequestTypes {

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -24,14 +24,15 @@ test('disable if no languages are present in the CMS', async () => {
   await languageTool.languages.row(0).locator.click();
   await languageTool.delete.click();
   await languageTool.delete.click();
-  await languageTool.save.click();
+  await languageTool.save.trigger.click();
+  await languageTool.save.save.click();
   await expect(add.trigger).toBeDisabled();
 
   await languageTool.trigger.click();
   await languageTool.add.trigger.click();
   await languageTool.add.languages.row(0).locator.click();
   await languageTool.add.add.click();
-  await languageTool.save.click();
+  await languageTool.save.trigger.click();
   await expect(add.trigger).toBeEnabled();
 });
 

--- a/playwright/tests/integration/mock/language-tool.spec.ts
+++ b/playwright/tests/integration/mock/language-tool.spec.ts
@@ -23,7 +23,7 @@ describe('default languages', () => {
     await expect(languageTool.checkboxOfRow(1)).not.toBeChecked();
 
     await languageTool.checkboxOfRow(1).check();
-    await languageTool.save.click();
+    await languageTool.save.trigger.click();
     await expect(table.headers).toHaveCount(3);
     await expect(table.header(1).content).toHaveText('English');
     await expect(table.header(2).content).toHaveText('German');
@@ -31,7 +31,7 @@ describe('default languages', () => {
 
     await languageTool.trigger.click();
     await languageTool.checkboxOfRow(0).uncheck();
-    await languageTool.save.click();
+    await languageTool.save.trigger.click();
     await expect(table.headers).toHaveCount(2);
     await expect(table.header(1).content).toHaveText('German');
     await table.row(0).expectToBeSelected();
@@ -60,7 +60,8 @@ describe('default languages', () => {
     await languageTool.checkboxOfRow(0).uncheck();
     await languageTool.languages.row(2).locator.click();
     await languageTool.delete.click();
-    await languageTool.save.click();
+    await languageTool.save.trigger.click();
+    await languageTool.save.save.click();
     await expect(table.headers).toHaveCount(2);
     await expect(table.header(1).content).toHaveText('French');
     const defaultLanguageTags = await editor.page.evaluate(() => localStorage.getItem('cms-editor-default-language-tags'));
@@ -101,7 +102,7 @@ describe('languages', () => {
     await languageTool.add.add.click();
 
     await languageTool.expectToHaveLanguages('English', 'French', 'German');
-    await languageTool.save.click();
+    await languageTool.save.trigger.click();
 
     await expect(editor.detail.value('French').locator).toBeVisible();
   });
@@ -117,7 +118,8 @@ describe('languages', () => {
     await languageTool.delete.click();
     await languageTool.expectToHaveLanguages('German');
     await languageTool.languages.row(0).expectToBeSelected();
-    await languageTool.save.click();
+    await languageTool.save.trigger.click();
+    await languageTool.save.save.click();
 
     await expect(editor.main.table.headers).toHaveCount(1);
   });
@@ -133,7 +135,8 @@ describe('languages', () => {
     await languageTool.trigger.click();
     await languageTool.languages.row(1).locator.click();
     await languageTool.delete.click();
-    await languageTool.save.click();
+    await languageTool.save.trigger.click();
+    await languageTool.save.save.click();
     await editor.main.table.row(0).expectToBeSelected();
     await expect(editor.main.table.row(0).column(0).value(0)).toHaveText('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks');
     await expect(editor.detail.uri.locator).toHaveValue('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks');

--- a/playwright/tests/pageobjects/main/LanguageTool.ts
+++ b/playwright/tests/pageobjects/main/LanguageTool.ts
@@ -1,5 +1,6 @@
 import { expect, type Locator, type Page } from '@playwright/test';
 import { AddLanguage } from './AddLanguage';
+import { LanguageToolSaveConfirmation } from './LanguageToolSaveConfirmation';
 import { Table } from './Table';
 
 export class LanguageTool {
@@ -8,7 +9,7 @@ export class LanguageTool {
   readonly add: AddLanguage;
   readonly delete: Locator;
   readonly languages: Table;
-  readonly save: Locator;
+  readonly save: LanguageToolSaveConfirmation;
 
   constructor(page: Page, parent: Locator) {
     this.locator = page.getByRole('dialog');
@@ -16,7 +17,7 @@ export class LanguageTool {
     this.add = new AddLanguage(page, this.locator);
     this.delete = this.locator.getByRole('button', { name: 'Delete Language' });
     this.languages = new Table(this.locator);
-    this.save = this.locator.getByRole('button', { name: 'Save' });
+    this.save = new LanguageToolSaveConfirmation(page, this.locator);
   }
 
   async expectToHaveLanguages(...languages: Array<string>) {

--- a/playwright/tests/pageobjects/main/LanguageToolSaveConfirmation.ts
+++ b/playwright/tests/pageobjects/main/LanguageToolSaveConfirmation.ts
@@ -1,0 +1,15 @@
+import type { Locator, Page } from '@playwright/test';
+
+export class LanguageToolSaveConfirmation {
+  readonly locator: Locator;
+  readonly trigger: Locator;
+  readonly cancel: Locator;
+  readonly save: Locator;
+
+  constructor(page: Page, parent: Locator) {
+    this.locator = page.getByRole('dialog', { name: 'Confirm Save' });
+    this.trigger = parent.getByRole('button', { name: 'Save' });
+    this.cancel = this.locator.getByRole('button', { name: 'Cancel' });
+    this.save = this.locator.getByRole('button', { name: 'Save' });
+  }
+}


### PR DESCRIPTION
If at least one language with values is about to be deleted, clicking the "Save" button will open a confirmation dialog. The confirmation dialog displays all languages with values about to be deleted with the respective amount of values. The user can choose to either cancel the deletion or proceed with it. Everything works using only the keyboard as well.