### PR TITLE
XIVY-16623 remove enter shortcut in language tool

### DIFF
--- a/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageTool.tsx
@@ -93,6 +93,7 @@ export const LanguageTool = () => {
           label={cell.getValue()}
           checked={defaultLanguages.includes(cell.row.original.value)}
           onCheckedChange={(checked: boolean) => onCheckedChange(checked, cell.row.original.value)}
+          tabIndex={-1}
         />
       )
     }

--- a/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.tsx
+++ b/packages/cms-editor/src/main/control/language-tool/LanguageToolSaveConfirmation.tsx
@@ -8,8 +8,7 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-  Flex,
-  useHotkeys
+  Flex
 } from '@axonivy/ui-components';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -37,8 +36,6 @@ export const LanguageToolSaveConfirmation = ({ localesToDelete, save }: Language
       setOpen(open);
     }
   };
-
-  useHotkeys(['Enter'], () => onOpenChange(true), { scopes: ['global'], keyup: true, enableOnFormTags: true });
 
   const languageValuesDisplayString = (languageTag: string, amount: number) => {
     const valueDisplayString = amount === 1 ? t('common.label.value') : t('common.label.values');

--- a/playwright/tests/integration/mock/language-tool.spec.ts
+++ b/playwright/tests/integration/mock/language-tool.spec.ts
@@ -84,6 +84,7 @@ test('open, edit, and save using keyboard', async () => {
   await keyboard.press('Space');
   await keyboard.press('ArrowDown');
   await keyboard.press('Space');
+  await keyboard.press('Tab');
   await keyboard.press('Enter');
   await expect(languageTool.locator).toBeHidden();
   await expect(editor.main.table.header(1).content).toHaveText('German');
@@ -315,8 +316,10 @@ describe('save confirmation', () => {
 
     await languageTool.languages.row(1).locator.click();
     await keyboard.press('Delete');
+    await keyboard.press('Tab');
     await keyboard.press('Enter');
     await expect(languageTool.save.locator).toBeVisible();
+    await expect(languageTool.save.cancel).toBeFocused();
 
     await keyboard.press('Escape');
     await expect(languageTool.save.locator).toBeHidden();


### PR DESCRIPTION
This solves a lot of issues with handling shortcuts in the Language Tool.
Also fixed being able to tab through the elements in the Language Tool.
