### PR TITLE
XIVY-16203 use new file endpoints

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -1,18 +1,26 @@
-import { removeValue } from '@axonivy/cms-editor';
+import {
+  isCmsFileDataObject,
+  isCmsStringDataObject,
+  isCmsValueDataObject,
+  removeValue,
+  type CmsValueDataObject
+} from '@axonivy/cms-editor';
 import type {
   Client,
   CmsActionArgs,
   CmsAddLocalesArgs,
   CmsCountLocaleValuesArgs,
-  CmsCreateArgs,
+  CmsCreateFileArgs,
+  CmsCreateStringArgs,
   CmsData,
   CmsDataObject,
   CmsDeleteArgs,
   CmsDeleteValueArgs,
   CmsReadArgs,
   CmsRemoveLocalesArgs,
+  CmsUpdateFileValueArgs,
+  CmsUpdateStringValueArgs,
   CmsUpdateValueArgs,
-  ContentObject,
   MetaRequestTypes,
   Void
 } from '@axonivy/cms-editor-protocol';
@@ -27,7 +35,15 @@ export class CmsClientMock implements Client {
     return Promise.resolve(this.cmsData);
   }
 
-  async create(args: CmsCreateArgs): Promise<Void> {
+  createString(args: CmsCreateStringArgs): Promise<Void> {
+    return this.create(args);
+  }
+
+  createFile(args: CmsCreateFileArgs): Promise<Void> {
+    return this.create(args);
+  }
+
+  private async create(args: CmsCreateStringArgs | CmsCreateFileArgs): Promise<Void> {
     const uri = args.contentObject.uri;
     if (uri.endsWith('IsPending')) {
       await new Promise(res => setTimeout(res, 1000));
@@ -40,22 +56,32 @@ export class CmsClientMock implements Client {
   }
 
   read(args: CmsReadArgs): Promise<CmsDataObject> {
-    return Promise.resolve(this.cmsData.data.find(data => data.uri === args.uri) ?? ({} as CmsDataObject));
+    return Promise.resolve(this.findContentObject(args.uri) ?? ({} as CmsDataObject));
   }
 
-  updateValue(args: CmsUpdateValueArgs): void {
-    const co = this.cmsData.data.find(co => co.uri === args.updateObject.uri);
-    if (co) {
-      co.values = { ...co.values, [args.updateObject.languageTag]: args.updateObject.value };
+  updateStringValue = (args: CmsUpdateStringValueArgs): void => {
+    this.updateValue(args, isCmsStringDataObject);
+  };
+
+  updateFileValue = (args: CmsUpdateFileValueArgs): void => {
+    this.updateValue(args, isCmsFileDataObject);
+  };
+
+  private updateValue<T extends CmsValueDataObject>(args: CmsUpdateValueArgs, typeCheck: (co: CmsDataObject) => co is T) {
+    const co = this.findContentObject(args.updateObject.uri);
+    if (co && typeCheck(co)) {
+      co.values = { ...co.values, [args.updateObject.languageTag]: args.updateObject.value } as T['values'];
     }
   }
 
   deleteValue(args: CmsDeleteValueArgs): void {
-    const co = this.cmsData.data.find(co => co.uri === args.deleteObject.uri);
-    if (co) {
+    const co = this.findContentObject(args.deleteObject.uri);
+    if (co && isCmsValueDataObject(co)) {
       co.values = removeValue(co.values, args.deleteObject.languageTag);
     }
   }
+
+  private findContentObject = (uri: string) => this.cmsData.data.find(co => co.uri === uri);
 
   delete(args: CmsDeleteArgs): void {
     this.cmsData = { ...this.cmsData, data: this.cmsData.data.filter(co => co.uri !== args.uri) };
@@ -69,11 +95,14 @@ export class CmsClientMock implements Client {
     this.localesData = this.localesData.filter(locale => !(args as CmsRemoveLocalesArgs).locales.includes(locale));
     this.cmsData = {
       ...this.cmsData,
-      data: this.cmsData.data.map(co => this.removeLocaleValues(co, args.locales)).filter(co => Object.entries(co.values).length !== 0)
+      data: this.cmsData.data
+        .filter(co => isCmsValueDataObject(co))
+        .map(co => this.removeLocaleValues(co, args.locales))
+        .filter(co => Object.entries(co.values).length !== 0)
     };
   }
 
-  private removeLocaleValues = (co: ContentObject, locales: Array<string>) => ({
+  private removeLocaleValues = (co: CmsValueDataObject, locales: Array<string>) => ({
     ...co,
     values: Object.fromEntries(Object.entries(co.values).filter(entry => !locales.includes(entry[0])))
   });
@@ -92,17 +121,19 @@ export class CmsClientMock implements Client {
   }
 
   private countLocaleValues = (locales: Array<string>) => {
-    return this.cmsData.data.reduce(
-      (localeValuesAmount, co) => {
-        locales.forEach(locale => {
-          if (co.values[locale] !== undefined) {
-            localeValuesAmount[locale] = ++localeValuesAmount[locale];
-          }
-        });
-        return localeValuesAmount;
-      },
-      Object.fromEntries(locales.map(locale => [locale, 0]))
-    );
+    return this.cmsData.data
+      .filter(co => isCmsValueDataObject(co))
+      .reduce(
+        (localeValuesAmount, co) => {
+          locales.forEach(locale => {
+            if (co.values[locale] !== undefined) {
+              localeValuesAmount[locale] = ++localeValuesAmount[locale];
+            }
+          });
+          return localeValuesAmount;
+        },
+        Object.fromEntries(locales.map(locale => [locale, 0]))
+      );
   };
 
   action(action: CmsActionArgs): void {

--- a/integrations/standalone/src/mock/data.ts
+++ b/integrations/standalone/src/mock/data.ts
@@ -3,9 +3,9 @@ import type { CmsData } from '@axonivy/cms-editor-protocol';
 export const contentObjects: CmsData = {
   context: { app: '', pmv: '', file: '' },
   data: [
-    { uri: '/Dialogs', type: 'FOLDER', values: {} },
-    { uri: '/Dialogs/agileBPM', type: 'FOLDER', values: {} },
-    { uri: '/Dialogs/agileBPM/define_WF', type: 'FOLDER', values: {} },
+    { uri: '/Dialogs', type: 'FOLDER' },
+    { uri: '/Dialogs/agileBPM', type: 'FOLDER' },
+    { uri: '/Dialogs/agileBPM/define_WF', type: 'FOLDER' },
     {
       uri: '/Dialogs/agileBPM/define_WF/AddTask',
       type: 'STRING',
@@ -54,7 +54,7 @@ export const contentObjects: CmsData = {
     { uri: '/Dialogs/agileBPM/define_WF/WFUser', type: 'STRING', values: { de: 'WF Benutzer', en: 'WF User' } },
     { uri: '/Dialogs/agileBPM/define_WF/Workflow', type: 'STRING', values: { de: 'Workflow', en: 'Workflow' } },
     { uri: '/Dialogs/agileBPM/define_WF/YourComment', type: 'STRING', values: { de: 'Ihr Kommentar', en: 'Your comment' } },
-    { uri: '/Dialogs/agileBPM/task_Form', type: 'FOLDER', values: {} },
+    { uri: '/Dialogs/agileBPM/task_Form', type: 'FOLDER' },
     { uri: '/Dialogs/agileBPM/task_Form/AddAdHocTask', type: 'STRING', values: { de: 'Ad-Hoc Aufgabe hinzufügen', en: 'Add ad-hoc task' } },
     { uri: '/Dialogs/agileBPM/task_Form/Append', type: 'STRING', values: { de: 'Anfügen', en: 'Append' } },
     {
@@ -97,11 +97,11 @@ export const contentObjects: CmsData = {
     { uri: '/Dialogs/agileBPM/task_Form/YesOK', type: 'STRING', values: { de: 'Ja, ok', en: 'Yes, its ok' } },
     { uri: '/Dialogs/agileBPM/task_Form/YourComment', type: 'STRING', values: { de: 'Ihr Kommentar', en: 'Your comment' } },
     { uri: '/Dialogs/agileBPM/task_Form/YourDecision', type: 'STRING', values: { de: 'Ihre Entscheidung', en: 'Your decision' } },
-    { uri: '/Dialogs/general', type: 'FOLDER', values: {} },
+    { uri: '/Dialogs/general', type: 'FOLDER' },
     { uri: '/Dialogs/general/locale', type: 'STRING', values: { en: 'de_CH' } },
     { uri: '/Dialogs/general/name', type: 'STRING', values: { de: 'Name', en: 'Name' } },
     { uri: '/Dialogs/general/proceed', type: 'STRING', values: { de: 'Durchführen', en: 'Proceed' } },
-    { uri: '/Dialogs/procurementRequest', type: 'FOLDER', values: {} },
+    { uri: '/Dialogs/procurementRequest', type: 'FOLDER' },
     { uri: '/Dialogs/procurementRequest/accept', type: 'STRING', values: { de: 'Akzeptieren', en: 'Accept' } },
     {
       uri: '/Dialogs/procurementRequest/acceptDescription',
@@ -154,7 +154,7 @@ export const contentObjects: CmsData = {
       type: 'STRING',
       values: { de: 'Beschaffungsantrag prüfen', en: 'Verify Procurement Request' }
     },
-    { uri: '/Dialogs/signal', type: 'FOLDER', values: {} },
+    { uri: '/Dialogs/signal', type: 'FOLDER' },
     { uri: '/Dialogs/signal/city', type: 'STRING', values: { de: 'Stadt', en: 'City' } },
     { uri: '/Dialogs/signal/createProcesses', type: 'STRING', values: { de: 'Prozesse erstellen', en: 'Create Processes' } },
     {
@@ -182,7 +182,7 @@ export const contentObjects: CmsData = {
     { uri: '/Dialogs/signal/reason', type: 'STRING', values: { de: 'Begründung', en: 'Reason' } },
     { uri: '/Dialogs/signal/street', type: 'STRING', values: { de: 'Strasse', en: 'Street' } },
     { uri: '/Dialogs/signal/userKey', type: 'STRING', values: { de: 'Benutzerkennung', en: 'User Key' } },
-    { uri: '/Dialogs/trigger', type: 'FOLDER', values: {} },
+    { uri: '/Dialogs/trigger', type: 'FOLDER' },
     { uri: '/Dialogs/trigger/dateOfBirth', type: 'STRING', values: { de: 'Geburtsdatum', en: 'Date Of Birth' } },
     { uri: '/Dialogs/trigger/email', type: 'STRING', values: { de: 'E-Mail', en: 'E-Mail' } },
     { uri: '/Dialogs/trigger/employee', type: 'STRING', values: { de: 'Mitarbeiter', en: 'Employee' } },
@@ -195,8 +195,16 @@ export const contentObjects: CmsData = {
     { uri: '/Dialogs/trigger/parkingLotNeeded', type: 'STRING', values: { de: 'Parkplatz benötigt', en: 'Parking Lot needed' } },
     { uri: '/Dialogs/trigger/parkingLotNr', type: 'STRING', values: { de: 'Parkplatznr.', en: 'Parking Lot Nr.' } },
     { uri: '/Dialogs/trigger/selectParkingLot', type: 'STRING', values: { de: 'Parkplatz auswählen', en: 'Select parking lot' } },
-    { uri: '/Files', type: 'FOLDER', values: {} },
-    { uri: '/Files/TextFile', type: 'FILE', values: { de: 'SW5oYWx0', en: 'Q29udGVudA==' }, meta: { fileExtension: 'txt' } }
+    { uri: '/Files', type: 'FOLDER' },
+    {
+      uri: '/Files/TextFile',
+      type: 'FILE',
+      values: {
+        de: Array.from('Inhalt').map(c => c.charCodeAt(0)),
+        en: Array.from('Content').map(c => c.charCodeAt(0))
+      },
+      fileExtension: 'txt'
+    }
   ],
   helpUrl: 'https://dev.axonivy.com'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,8 @@
         "@axonivy/jsonrpc": "~13.2.0-next.720",
         "@axonivy/ui-components": "~13.2.0-next.720",
         "@axonivy/ui-icons": "~13.2.0-next.720",
-        "@tanstack/react-query": "^5.80.10",
-        "@tanstack/react-query-devtools": "^5.80.10",
+        "@tanstack/react-query": "^5.64",
+        "@tanstack/react-query-devtools": "^5.64",
         "i18next": "^25.0.0",
         "i18next-browser-languagedetector": "^8.0.4",
         "react": "^19.0.0",
@@ -16399,7 +16399,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "vite-plugin-dts": "^4.5.0",
-        "vitest": "^3.2.4"
+        "vitest": "^3.0.3"
       },
       "peerDependencies": {
         "@axonivy/jsonrpc": "~13.2.0-next",

--- a/packages/cms-editor/src/CmsEditor.test.ts
+++ b/packages/cms-editor/src/CmsEditor.test.ts
@@ -1,13 +1,13 @@
-import type { ContentObject } from '@axonivy/cms-editor-protocol';
+import type { CmsDataObject } from '@axonivy/cms-editor-protocol';
 import { toolbarTitles } from './CmsEditor';
 
 test('toolbarTitles', () => {
   expect(toolbarTitles('pmv-name')).toEqual({ mainTitle: 'CMS - pmv-name', detailTitle: 'CMS - pmv-name' });
-  expect(toolbarTitles('pmv-name', { uri: 'content-object-uri' } as ContentObject)).toEqual({
+  expect(toolbarTitles('pmv-name', { uri: 'content-object-uri' } as CmsDataObject)).toEqual({
     mainTitle: 'CMS - pmv-name',
     detailTitle: 'CMS - pmv-name - content-object-uri'
   });
-  expect(toolbarTitles('pmv-name', { uri: 'folder/content-object-uri' } as ContentObject)).toEqual({
+  expect(toolbarTitles('pmv-name', { uri: 'folder/content-object-uri' } as CmsDataObject)).toEqual({
     mainTitle: 'CMS - pmv-name',
     detailTitle: 'CMS - pmv-name - content-object-uri'
   });

--- a/packages/cms-editor/src/CmsEditor.tsx
+++ b/packages/cms-editor/src/CmsEditor.tsx
@@ -1,4 +1,4 @@
-import type { ContentObject, EditorProps } from '@axonivy/cms-editor-protocol';
+import type { CmsDataObject, EditorProps } from '@axonivy/cms-editor-protocol';
 import { Flex, PanelMessage, ResizableHandle, ResizablePanel, ResizablePanelGroup, Spinner, useHotkeys } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useQuery } from '@tanstack/react-query';
@@ -14,6 +14,7 @@ import { useClient } from './protocol/ClientContextProvider';
 import { useAction } from './protocol/use-action';
 import { useQueryKeys } from './query/query-client';
 import { useLanguages } from './use-languages';
+import { isCmsValueDataObject } from './utils/cms-utils';
 import { useKnownHotkeys } from './utils/hotkeys';
 
 function CmsEditor(props: EditorProps) {
@@ -53,7 +54,7 @@ function CmsEditor(props: EditorProps) {
     return <PanelMessage icon={IvyIcons.ErrorXMark} message={t('message.error', { error })} />;
   }
 
-  const contentObjects = data.data.filter((contentObject: ContentObject) => contentObject.type !== 'FOLDER');
+  const contentObjects = data.data.filter((contentObject: CmsDataObject) => isCmsValueDataObject(contentObject));
   const contentObject = selectedContentObject !== undefined ? contentObjects[selectedContentObject] : undefined;
   const { mainTitle, detailTitle } = toolbarTitles(context.pmv, contentObject);
 
@@ -96,7 +97,7 @@ function CmsEditor(props: EditorProps) {
 
 export default CmsEditor;
 
-export const toolbarTitles = (pmv: string, contentObject?: ContentObject) => {
+export const toolbarTitles = (pmv: string, contentObject?: CmsDataObject) => {
   const mainTitle = `CMS - ${pmv}`;
   let detailTitle = mainTitle;
   if (contentObject) {

--- a/packages/cms-editor/src/components/BaseValueField.tsx
+++ b/packages/cms-editor/src/components/BaseValueField.tsx
@@ -1,4 +1,4 @@
-import type { MapStringString } from '@axonivy/cms-editor-protocol';
+import type { CmsDataObjectValues } from '@axonivy/cms-editor-protocol';
 import {
   BasicField,
   Button,
@@ -13,8 +13,8 @@ import { IvyIcons } from '@axonivy/ui-icons';
 import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 
-export type BaseValueFieldProps = {
-  values: MapStringString;
+export type BaseValueFieldProps<T extends CmsDataObjectValues> = {
+  values: T;
   deleteValue: (languageTag: string) => void;
   label: string;
   languageTag: string;
@@ -35,7 +35,7 @@ export const BaseValueField = ({
   deleteTooltip,
   message,
   children
-}: BaseValueFieldProps) => {
+}: BaseValueFieldProps<CmsDataObjectValues>) => {
   const { t } = useTranslation();
   const readonly = useReadonly();
 

--- a/packages/cms-editor/src/components/FileValueField.test.ts
+++ b/packages/cms-editor/src/components/FileValueField.test.ts
@@ -1,6 +1,0 @@
-import { fileValue } from './FileValueField';
-
-test('value', async () => {
-  const file = new File(['test'], 'test.txt', { type: 'text/plain' });
-  expect(await fileValue(file)).toEqual('dGVzdA==');
-});

--- a/packages/cms-editor/src/components/FileValueField.tsx
+++ b/packages/cms-editor/src/components/FileValueField.tsx
@@ -1,10 +1,11 @@
+import type { MapStringByte } from '@axonivy/cms-editor-protocol';
 import { Input } from '@axonivy/ui-components';
 import { useRef } from 'react';
 import { BaseValueField, type BaseValueFieldProps } from './BaseValueField';
 import { ValueFieldTextArea } from './ValueFieldTextArea';
 
-type FileValueFieldProps = BaseValueFieldProps & {
-  updateValue: (languageTag: string, value: string) => void;
+type FileValueFieldProps = BaseValueFieldProps<MapStringByte> & {
+  updateValue: (languageTag: string, value: Array<number>) => void;
   deleteValue: (languageTag: string) => void;
   fileExtension?: string;
   setFileExtension?: (fileExtension?: string) => void;
@@ -26,7 +27,7 @@ export const FileValueField = ({ updateValue, deleteValue, fileExtension, setFil
   const onChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) {
-      updateValue(baseProps.languageTag, await fileValue(file));
+      updateValue(baseProps.languageTag, Array.from(new Uint8Array(await file.arrayBuffer())));
       setFileExtension?.(file.name.includes('.') ? file.name.slice(file.name.lastIndexOf('.') + 1) : '');
     }
   };
@@ -42,19 +43,7 @@ export const FileValueField = ({ updateValue, deleteValue, fileExtension, setFil
         disabled={baseProps.disabled}
         ref={inputRef}
       />
-      <ValueFieldTextArea value={value !== undefined ? window.atob(value) : undefined} disabled />
+      <ValueFieldTextArea value={value ? String.fromCharCode(...value) : undefined} disabled />
     </BaseValueField>
   );
-};
-
-export const fileValue = (file: File): Promise<string> => {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = reader.result as string;
-      resolve(result.slice(result.indexOf(',') + 1));
-    };
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
 };

--- a/packages/cms-editor/src/components/StringValueField.tsx
+++ b/packages/cms-editor/src/components/StringValueField.tsx
@@ -1,7 +1,8 @@
+import type { MapStringString } from '@axonivy/cms-editor-protocol';
 import { BaseValueField, type BaseValueFieldProps } from './BaseValueField';
 import { ValueFieldTextArea } from './ValueFieldTextArea';
 
-type StringValueFieldProps = BaseValueFieldProps & {
+type StringValueFieldProps = BaseValueFieldProps<MapStringString> & {
   updateValue: (languageTag: string, value: string) => void;
 };
 

--- a/packages/cms-editor/src/context/AppContext.tsx
+++ b/packages/cms-editor/src/context/AppContext.tsx
@@ -1,9 +1,10 @@
-import type { CmsEditorDataContext, ContentObject } from '@axonivy/cms-editor-protocol';
+import type { CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
 import { createContext, useContext } from 'react';
+import type { CmsValueDataObject } from '../utils/cms-utils';
 
 type AppContext = {
   context: CmsEditorDataContext;
-  contentObjects: Array<ContentObject>;
+  contentObjects: Array<CmsValueDataObject>;
   selectedContentObject?: number;
   setSelectedContentObject: (index?: number) => void;
   detail: boolean;

--- a/packages/cms-editor/src/context/test-utils/test-utils.tsx
+++ b/packages/cms-editor/src/context/test-utils/test-utils.tsx
@@ -1,11 +1,11 @@
-import type { Client, CmsEditorDataContext, ContentObject } from '@axonivy/cms-editor-protocol';
+import type { Client, CmsEditorDataContext } from '@axonivy/cms-editor-protocol';
 import { ReadonlyProvider } from '@axonivy/ui-components';
 import { QueryClient } from '@tanstack/react-query';
 import { render, renderHook, type RenderHookOptions, type RenderOptions } from '@testing-library/react';
 import i18n from 'i18next';
 import type { ReactNode } from 'react';
 import { initReactI18next } from 'react-i18next';
-import { enTranslation } from '../..';
+import { enTranslation, type CmsValueDataObject } from '../..';
 import { ClientContextProvider } from '../../protocol/ClientContextProvider';
 import { QueryProvider } from '../../query/QueryProvider';
 import { AppProvider } from '../AppContext';
@@ -20,7 +20,7 @@ type ContextHelperProps = {
   };
   appContext?: {
     context?: CmsEditorDataContext;
-    contentObjects?: Array<ContentObject>;
+    contentObjects?: Array<CmsValueDataObject>;
     selectedContentObject?: number;
     setSelectedContentObject?: (index?: number) => void;
     detail?: boolean;

--- a/packages/cms-editor/src/detail/DetailContent.test.ts
+++ b/packages/cms-editor/src/detail/DetailContent.test.ts
@@ -1,23 +1,28 @@
-import type { CmsData, MapStringString } from '@axonivy/cms-editor-protocol';
+import type { CmsData, CmsDataObject } from '@axonivy/cms-editor-protocol';
 import { updateValuesOfContentObjectInData } from './DetailContent';
 
 test('updateValuesOfContentObjectInData', () => {
   const data = {
     data: [
-      { uri: 'uriOne', values: { en: 'englishOne', de: 'deutschEins' } as MapStringString },
-      { uri: 'uriTwo', values: { en: 'englishTwo', de: 'deutschZwei' } as MapStringString }
-    ]
+      { uri: 'uriOne', type: 'STRING', values: { en: 'englishOne', de: 'deutschEins' } },
+      { uri: 'uriTwo', type: 'FILE', values: { en: 'englishTwo', de: 'deutschZwei' } },
+      { uri: 'uriThree', type: 'FOLDER' }
+    ] as Array<CmsDataObject>
   } as CmsData;
   expect(updateValuesOfContentObjectInData(data, 'uriOne', () => ({ new: 'values' }))).toEqual({
     data: [
-      { uri: 'uriOne', values: { new: 'values' } },
-      { uri: 'uriTwo', values: { en: 'englishTwo', de: 'deutschZwei' } }
+      { uri: 'uriOne', type: 'STRING', values: { new: 'values' } },
+      { uri: 'uriTwo', type: 'FILE', values: { en: 'englishTwo', de: 'deutschZwei' } },
+      { uri: 'uriThree', type: 'FOLDER' }
     ]
   });
   expect(updateValuesOfContentObjectInData(data, 'uriTwo', () => ({ new: 'values' }))).toEqual({
     data: [
-      { uri: 'uriOne', values: { en: 'englishOne', de: 'deutschEins' } },
-      { uri: 'uriTwo', values: { new: 'values' } }
+      { uri: 'uriOne', type: 'STRING', values: { en: 'englishOne', de: 'deutschEins' } },
+      { uri: 'uriTwo', type: 'FILE', values: { new: 'values' } },
+      { uri: 'uriThree', type: 'FOLDER' }
     ]
   });
+  expect(updateValuesOfContentObjectInData(data, 'uriThree', () => ({ new: 'values' }))).toBeUndefined();
+  expect(updateValuesOfContentObjectInData(data, 'uriFour', () => ({ new: 'values' }))).toBeUndefined();
 });

--- a/packages/cms-editor/src/main/control/AddContentObject.test.ts
+++ b/packages/cms-editor/src/main/control/AddContentObject.test.ts
@@ -1,10 +1,10 @@
-import type { Client, ContentObject } from '@axonivy/cms-editor-protocol';
+import type { Client, CmsDataObject } from '@axonivy/cms-editor-protocol';
 import { waitFor } from '@testing-library/react';
 import { customRenderHook } from '../../context/test-utils/test-utils';
 import { initialNamespace, namespaceOptions, useLanguageTags } from './AddContentObject';
 
 test('initialNamespace', () => {
-  const contentObjects = [{ uri: '/contentObject' }, { uri: '/folder/deep/contentObject' }] as Array<ContentObject>;
+  const contentObjects = [{ uri: '/contentObject' }, { uri: '/folder/deep/contentObject' }] as Array<CmsDataObject>;
   expect(initialNamespace(contentObjects, undefined)).toEqual('');
   expect(initialNamespace(contentObjects, 0)).toEqual('');
   expect(initialNamespace(contentObjects, 1)).toEqual('/folder/deep');
@@ -40,7 +40,7 @@ test('namespaceOptions', () => {
       { uri: '/c/c/a' },
       { uri: '/c/c/b' },
       { uri: '/d/a' }
-    ] as Array<ContentObject>)
+    ] as Array<CmsDataObject>)
   ).toEqual([{ value: '' }, { value: '/c' }, { value: '/c/c' }, { value: '/d' }]);
 });
 

--- a/packages/cms-editor/src/main/control/use-validate-add-content-object.test.ts
+++ b/packages/cms-editor/src/main/control/use-validate-add-content-object.test.ts
@@ -1,4 +1,4 @@
-import type { ContentObject, MapStringString } from '@axonivy/cms-editor-protocol';
+import type { CmsDataObject, MapStringString } from '@axonivy/cms-editor-protocol';
 import { customRenderHook } from '../../context/test-utils/test-utils';
 import { useValidateAddContentObject } from './use-validate-add-content-object';
 
@@ -20,21 +20,21 @@ test('nameMessage', () => {
   expect(
     renderUseValidateAddContentObject({
       name: 'testName',
-      contentObjects: [{ uri: '/testName' } as ContentObject]
+      contentObjects: [{ uri: '/testName' } as CmsDataObject]
     }).result.current.nameMessage
   ).toEqual(nameIsTakenMessage);
   expect(
     renderUseValidateAddContentObject({
       name: 'testName',
       namespace: 'testNamespace',
-      contentObjects: [{ uri: '/testNamespace/testName' } as ContentObject]
+      contentObjects: [{ uri: '/testNamespace/testName' } as CmsDataObject]
     }).result.current.nameMessage
   ).toEqual(nameIsTakenMessage);
   expect(
     renderUseValidateAddContentObject({
       name: 'tEstNamE',
       namespace: '/tEstNamEspacE',
-      contentObjects: [{ uri: '/testNamespace/testName' } as ContentObject]
+      contentObjects: [{ uri: '/testNamespace/testName' } as CmsDataObject]
     }).result.current.nameMessage
   ).toEqual(nameIsTakenMessage);
 
@@ -53,7 +53,7 @@ type renderUseValidateAddContentObjectProps = {
   name?: string;
   namespace?: string;
   values?: MapStringString;
-  contentObjects?: Array<ContentObject>;
+  contentObjects?: Array<CmsDataObject>;
 };
 
 const renderUseValidateAddContentObject = (props?: renderUseValidateAddContentObjectProps) => {

--- a/packages/cms-editor/src/main/control/use-validate-add-content-object.ts
+++ b/packages/cms-editor/src/main/control/use-validate-add-content-object.ts
@@ -1,4 +1,4 @@
-import type { ContentObject, MapStringString } from '@axonivy/cms-editor-protocol';
+import type { CmsDataObject, CmsDataObjectValues } from '@axonivy/cms-editor-protocol';
 import type { MessageData } from '@axonivy/ui-components';
 import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -6,8 +6,8 @@ import { useTranslation } from 'react-i18next';
 export const useValidateAddContentObject = (
   name: string,
   namespace: string,
-  values: MapStringString,
-  contentObjects: Array<ContentObject>
+  values: CmsDataObjectValues,
+  contentObjects: Array<CmsDataObject>
 ) => {
   const { t } = useTranslation();
 

--- a/packages/cms-editor/src/protocol/client-json-rpc.ts
+++ b/packages/cms-editor/src/protocol/client-json-rpc.ts
@@ -2,7 +2,8 @@ import type {
   Client,
   CmsActionArgs,
   CmsAddLocalesArgs,
-  CmsCreateArgs,
+  CmsCreateFileArgs,
+  CmsCreateStringArgs,
   CmsData,
   CmsDataArgs,
   CmsDataObject,
@@ -10,7 +11,8 @@ import type {
   CmsDeleteValueArgs,
   CmsReadArgs,
   CmsRemoveLocalesArgs,
-  CmsUpdateValueArgs,
+  CmsUpdateFileValueArgs,
+  CmsUpdateStringValueArgs,
   MetaRequestTypes,
   NotificationTypes,
   RequestTypes,
@@ -23,17 +25,25 @@ export class ClientJsonRpc extends BaseRpcClient implements Client {
     return this.sendRequest('data', args);
   }
 
-  create(args: CmsCreateArgs): Promise<Void> {
-    return this.sendRequest('create', args);
+  createString(args: CmsCreateStringArgs): Promise<Void> {
+    return this.sendRequest('createString', args);
+  }
+
+  createFile(args: CmsCreateFileArgs): Promise<Void> {
+    return this.sendRequest('createFile', args);
   }
 
   read(args: CmsReadArgs): Promise<CmsDataObject> {
     return this.sendRequest('read', args);
   }
 
-  updateValue(args: CmsUpdateValueArgs): void {
-    this.sendRequest('updateValue', args);
-  }
+  updateStringValue = (args: CmsUpdateStringValueArgs): void => {
+    this.sendRequest('updateStringValue', args);
+  };
+
+  updateFileValue = (args: CmsUpdateFileValueArgs): void => {
+    this.sendRequest('updateFileValue', args);
+  };
 
   deleteValue(args: CmsDeleteValueArgs): void {
     this.sendRequest('deleteValue', args);

--- a/packages/cms-editor/src/utils/cms-utils.test.ts
+++ b/packages/cms-editor/src/utils/cms-utils.test.ts
@@ -1,7 +1,34 @@
-import { removeValue } from './cms-utils';
+import type { CmsFileDataObject, CmsFolderDataObject, CmsStringDataObject } from '@axonivy/cms-editor-protocol';
+import { isCmsFileDataObject, isCmsFolderDataObject, isCmsStringDataObject, isCmsValueDataObject, removeValue } from './cms-utils';
 
 test('removeValue', () => {
   const values = { en: 'value', de: 'wert' };
   const newValues = removeValue(values, 'de');
   expect(newValues).toEqual({ en: 'value' });
+});
+
+test('CmsDataObject type guards', () => {
+  const folder = { type: 'FOLDER' } as CmsFolderDataObject;
+  const string = { type: 'STRING' } as CmsStringDataObject;
+  const file = { type: 'FILE' } as CmsFileDataObject;
+
+  expect(isCmsFolderDataObject(undefined)).toBeFalsy();
+  expect(isCmsFolderDataObject(folder)).toBeTruthy();
+  expect(isCmsFolderDataObject(string)).toBeFalsy();
+  expect(isCmsFolderDataObject(file)).toBeFalsy();
+
+  expect(isCmsStringDataObject(undefined)).toBeFalsy();
+  expect(isCmsStringDataObject(folder)).toBeFalsy();
+  expect(isCmsStringDataObject(string)).toBeTruthy();
+  expect(isCmsStringDataObject(file)).toBeFalsy();
+
+  expect(isCmsFileDataObject(undefined)).toBeFalsy();
+  expect(isCmsFileDataObject(folder)).toBeFalsy();
+  expect(isCmsFileDataObject(string)).toBeFalsy();
+  expect(isCmsFileDataObject(file)).toBeTruthy();
+
+  expect(isCmsValueDataObject(undefined)).toBeFalsy();
+  expect(isCmsValueDataObject(folder)).toBeFalsy();
+  expect(isCmsValueDataObject(string)).toBeTruthy();
+  expect(isCmsValueDataObject(file)).toBeTruthy();
 });

--- a/packages/cms-editor/src/utils/cms-utils.ts
+++ b/packages/cms-editor/src/utils/cms-utils.ts
@@ -6,10 +6,10 @@ import type {
   CmsStringDataObject
 } from '@axonivy/cms-editor-protocol';
 
-export const removeValue = <T extends CmsDataObjectValues>(values: T, languageTag: string) => {
+export const removeValue = (values: CmsDataObjectValues, languageTag: string): CmsDataObjectValues => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { [languageTag]: _, ...newValues } = values;
-  return newValues as T;
+  return newValues;
 };
 
 export const isCmsFolderDataObject = (object?: CmsDataObject): object is CmsFolderDataObject => object?.type === 'FOLDER';

--- a/packages/cms-editor/src/utils/cms-utils.ts
+++ b/packages/cms-editor/src/utils/cms-utils.ts
@@ -1,7 +1,21 @@
-import type { MapStringString } from '@axonivy/cms-editor-protocol';
+import type {
+  CmsDataObject,
+  CmsDataObjectValues,
+  CmsFileDataObject,
+  CmsFolderDataObject,
+  CmsStringDataObject
+} from '@axonivy/cms-editor-protocol';
 
-export const removeValue = (values: MapStringString, languageTag: string) => {
+export const removeValue = <T extends CmsDataObjectValues>(values: T, languageTag: string) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { [languageTag]: _, ...newValues } = values;
-  return newValues;
+  return newValues as T;
 };
+
+export const isCmsFolderDataObject = (object?: CmsDataObject): object is CmsFolderDataObject => object?.type === 'FOLDER';
+export const isCmsStringDataObject = (object?: CmsDataObject): object is CmsStringDataObject => object?.type === 'STRING';
+export const isCmsFileDataObject = (object?: CmsDataObject): object is CmsFileDataObject => object?.type === 'FILE';
+
+export type CmsValueDataObject = CmsStringDataObject | CmsFileDataObject;
+export const isCmsValueDataObject = (object?: CmsDataObject): object is CmsValueDataObject =>
+  isCmsStringDataObject(object) || isCmsFileDataObject(object);

--- a/packages/protocol/src/editor.ts
+++ b/packages/protocol/src/editor.ts
@@ -7,12 +7,14 @@
  */
 
 export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
+export type CmsDataObject = CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject;
 
 export interface CMS {
   cmsActionArgs: CmsActionArgs;
   cmsAddLocalesArgs: CmsAddLocalesArgs;
   cmsCountLocaleValuesArgs: CmsCountLocaleValuesArgs;
-  cmsCreateArgs: CmsCreateArgs;
+  cmsCreateFileArgs: CmsCreateFileArgs;
+  cmsCreateStringArgs: CmsCreateStringArgs;
   cmsData: CmsData;
   cmsDataArgs: CmsDataArgs;
   cmsDataObject: CmsDataObject;
@@ -21,7 +23,8 @@ export interface CMS {
   cmsEditorDataContext: CmsEditorDataContext;
   cmsReadArgs: CmsReadArgs;
   cmsRemoveLocalesArgs: CmsRemoveLocalesArgs;
-  cmsUpdateValueArgs: CmsUpdateValueArgs;
+  cmsUpdateFileValueArgs: CmsUpdateFileValueArgs;
+  cmsUpdateStringValueArgs: CmsUpdateStringValueArgs;
   long: MapStringLong;
   string: string[];
   void: Void;
@@ -45,26 +48,39 @@ export interface CmsCountLocaleValuesArgs {
   context: CmsEditorDataContext;
   locales: string[];
 }
-export interface CmsCreateArgs {
-  contentObject: CmsDataObject;
+export interface CmsCreateFileArgs {
+  contentObject: CmsFileDataObject;
   context: CmsEditorDataContext;
 }
-export interface CmsDataObject {
-  meta?: Meta;
+export interface CmsFileDataObject {
+  fileExtension: string;
+  type: ContentObjectType;
+  uri: string;
+  values: MapStringByte;
+}
+export interface MapStringByte {
+  [k: string]: Array<number>;
+}
+export interface CmsCreateStringArgs {
+  contentObject: CmsStringDataObject;
+  context: CmsEditorDataContext;
+}
+export interface CmsStringDataObject {
   type: ContentObjectType;
   uri: string;
   values: MapStringString;
-}
-export interface Meta {
-  fileExtension: string;
 }
 export interface MapStringString {
   [k: string]: string;
 }
 export interface CmsData {
   context: CmsEditorDataContext;
-  data: CmsDataObject[];
+  data: (CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject)[];
   helpUrl: string;
+}
+export interface CmsFolderDataObject {
+  type: ContentObjectType;
+  uri: string;
 }
 export interface CmsDataArgs {
   context: CmsEditorDataContext;
@@ -90,11 +106,20 @@ export interface CmsRemoveLocalesArgs {
   context: CmsEditorDataContext;
   locales: string[];
 }
-export interface CmsUpdateValueArgs {
+export interface CmsUpdateFileValueArgs {
   context: CmsEditorDataContext;
-  updateObject: CmsUpdateValueObject;
+  updateObject: CmsUpdateFileValueObject;
 }
-export interface CmsUpdateValueObject {
+export interface CmsUpdateFileValueObject {
+  languageTag: string;
+  uri: string;
+  value: Array<number>;
+}
+export interface CmsUpdateStringValueArgs {
+  context: CmsEditorDataContext;
+  updateObject: CmsUpdateStringValueObject;
+}
+export interface CmsUpdateStringValueObject {
   languageTag: string;
   uri: string;
   value: string;

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -2,7 +2,8 @@ import type {
   CmsActionArgs,
   CmsAddLocalesArgs,
   CmsCountLocaleValuesArgs,
-  CmsCreateArgs,
+  CmsCreateFileArgs,
+  CmsCreateStringArgs,
   CmsData,
   CmsDataArgs,
   CmsDataObject,
@@ -11,20 +12,27 @@ import type {
   CmsEditorDataContext,
   CmsReadArgs,
   CmsRemoveLocalesArgs,
-  CmsUpdateValueArgs,
+  CmsUpdateFileValueArgs,
+  CmsUpdateStringValueArgs,
+  MapStringByte,
   MapStringLong,
+  MapStringString,
   Void
 } from './editor';
 
 export type EditorProps = { context: CmsEditorDataContext };
 
-export type { CmsDataObject as ContentObject };
+export type CmsDataObjectValues = MapStringString | MapStringByte;
+export type CmsCreateObjectArgs = CmsCreateStringArgs | CmsCreateFileArgs;
+export type CmsUpdateValueArgs = CmsUpdateStringValueArgs | CmsUpdateFileValueArgs;
 
 export interface Client {
   data(args: CmsDataArgs): Promise<CmsData>;
-  create(args: CmsCreateArgs): Promise<Void>;
+  createString(args: CmsCreateStringArgs): Promise<Void>;
+  createFile(args: CmsCreateFileArgs): Promise<Void>;
   read(args: CmsReadArgs): Promise<CmsDataObject>;
-  updateValue(args: CmsUpdateValueArgs): void;
+  updateStringValue(args: CmsUpdateStringValueArgs): void;
+  updateFileValue(args: CmsUpdateFileValueArgs): void;
   deleteValue(args: CmsDeleteValueArgs): void;
   delete(args: CmsDeleteArgs): void;
   addLocales(args: CmsAddLocalesArgs): void;
@@ -45,9 +53,11 @@ export interface MetaRequestTypes {
 
 export interface RequestTypes extends MetaRequestTypes {
   data: [CmsDataArgs, CmsData];
-  create: [CmsCreateArgs, Void];
+  createString: [CmsCreateStringArgs, Void];
+  createFile: [CmsCreateFileArgs, Void];
   read: [CmsReadArgs, CmsDataObject];
-  updateValue: [CmsUpdateValueArgs, Void];
+  updateStringValue: [CmsUpdateStringValueArgs, Void];
+  updateFileValue: [CmsUpdateFileValueArgs, Void];
   deleteValue: [CmsDeleteValueArgs, Void];
   delete: [CmsDeleteArgs, Void];
   addLocales: [CmsAddLocalesArgs, Void];


### PR DESCRIPTION
Core change: https://github.com/axonivy/core/pull/9455

I tried to share as much code as possible while handling `FILE` and `STRING` Content Objects simultaneously. I'm not entirely satisfied with every detail, but I also don't know how to improve it without introducing excessive redundancy. At least this works for now.