### PR TITLE
XIVY-16203 display buttons instead of file values

### DIFF
--- a/integrations/standalone/src/mock/data.ts
+++ b/integrations/standalone/src/mock/data.ts
@@ -196,15 +196,7 @@ export const contentObjects: CmsData = {
     { uri: '/Dialogs/trigger/parkingLotNr', type: 'STRING', values: { de: 'Parkplatznr.', en: 'Parking Lot Nr.' } },
     { uri: '/Dialogs/trigger/selectParkingLot', type: 'STRING', values: { de: 'Parkplatz auswählen', en: 'Select parking lot' } },
     { uri: '/Files', type: 'FOLDER' },
-    {
-      uri: '/Files/TextFile',
-      type: 'FILE',
-      values: {
-        de: Array.from('Inhalt').map(c => c.charCodeAt(0)),
-        en: Array.from('Content').map(c => c.charCodeAt(0))
-      },
-      fileExtension: 'txt'
-    }
+    { uri: '/Files/TextFile', type: 'FILE', values: { de: true, en: true }, fileExtension: 'txt' }
   ],
   helpUrl: 'https://dev.axonivy.com'
 };

--- a/packages/cms-editor/src/components/FileValueField.css
+++ b/packages/cms-editor/src/components/FileValueField.css
@@ -1,0 +1,3 @@
+.cms-editor-file-value-field {
+  align-items: center;
+}

--- a/packages/cms-editor/src/components/FileValueField.tsx
+++ b/packages/cms-editor/src/components/FileValueField.tsx
@@ -1,17 +1,29 @@
 import type { MapStringByte } from '@axonivy/cms-editor-protocol';
-import { Input } from '@axonivy/ui-components';
+import { Button, Flex, Input } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
 import { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { BaseValueField, type BaseValueFieldProps } from './BaseValueField';
-import { ValueFieldTextArea } from './ValueFieldTextArea';
+import './FileValueField.css';
 
 type FileValueFieldProps = BaseValueFieldProps<MapStringByte> & {
   updateValue: (languageTag: string, value: Array<number>) => void;
   deleteValue: (languageTag: string) => void;
   fileExtension?: string;
   setFileExtension?: (fileExtension?: string) => void;
+  allowOpenFile?: boolean;
 };
 
-export const FileValueField = ({ updateValue, deleteValue, fileExtension, setFileExtension, ...baseProps }: FileValueFieldProps) => {
+export const FileValueField = ({
+  updateValue,
+  deleteValue,
+  fileExtension,
+  setFileExtension,
+  allowOpenFile,
+  ...baseProps
+}: FileValueFieldProps) => {
+  const { t } = useTranslation();
+
   const inputRef = useRef<HTMLInputElement>(null);
 
   const deleteFileValue = (languageTag: string) => {
@@ -32,18 +44,18 @@ export const FileValueField = ({ updateValue, deleteValue, fileExtension, setFil
     }
   };
 
-  const value = baseProps.values[baseProps.languageTag];
-
   return (
     <BaseValueField deleteValue={deleteFileValue} {...baseProps}>
-      <Input
-        type='file'
-        accept={fileExtension ? `.${fileExtension}` : undefined}
-        onChange={onChange}
-        disabled={baseProps.disabled}
-        ref={inputRef}
-      />
-      <ValueFieldTextArea value={value ? String.fromCharCode(...value) : undefined} disabled />
+      <Flex gap={2} className='cms-editor-file-value-field'>
+        <Input
+          type='file'
+          accept={fileExtension ? `.${fileExtension}` : undefined}
+          onChange={onChange}
+          disabled={baseProps.disabled}
+          ref={inputRef}
+        />
+        {allowOpenFile && baseProps.values[baseProps.languageTag] && <Button icon={IvyIcons.File} aria-label={t('value.openFile')} />}
+      </Flex>
     </BaseValueField>
   );
 };

--- a/packages/cms-editor/src/detail/DetailContent.tsx
+++ b/packages/cms-editor/src/detail/DetailContent.tsx
@@ -136,6 +136,7 @@ export const DetailContent = () => {
                 updateFileValueMutation.mutate({ context, updateObject: { uri, languageTag, value } })
               }
               fileExtension={contentObject.fileExtension}
+              allowOpenFile
               {...props}
             />
           ) : (

--- a/packages/cms-editor/src/main/MainContent.css
+++ b/packages/cms-editor/src/main/MainContent.css
@@ -39,6 +39,10 @@
   overflow: hidden;
 }
 
+.cms-editor-main-table tbody tr {
+  align-items: center;
+}
+
 .cms-editor-main-table span {
   display: block;
   white-space: nowrap;

--- a/packages/cms-editor/src/main/MainContent.tsx
+++ b/packages/cms-editor/src/main/MainContent.tsx
@@ -2,6 +2,7 @@ import { type CmsData, type CmsDeleteArgs } from '@axonivy/cms-editor-protocol';
 import {
   adjustSelectionAfterDeletionOfRow,
   BasicField,
+  Button,
   Flex,
   SelectRow,
   selectRow,
@@ -17,10 +18,11 @@ import {
   useTableSelect,
   useTableSort
 } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, type ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../context/AppContext';
 import { useClient } from '../protocol/ClientContextProvider';
@@ -63,7 +65,7 @@ export const MainContent = () => {
   const globalFilter = useTableGlobalFilter();
 
   const columns = useMemo(() => {
-    const columns: Array<ColumnDef<CmsValueDataObject, string>> = [
+    const columns: Array<ColumnDef<CmsValueDataObject, string | ReactElement>> = [
       {
         accessorKey: 'uri',
         header: ({ column }) => <SortableHeader column={column} name='URI' />,
@@ -78,8 +80,7 @@ export const MainContent = () => {
         id: language.value,
         accessorFn: co => {
           if (isCmsFileDataObject(co)) {
-            const value = co.values[language.value];
-            return value ? String.fromCharCode(...value) : '';
+            return co.values[language.value] ? <Button icon={IvyIcons.File} aria-label={t('value.openFile')} /> : '';
           }
           return co.values[language.value];
         },
@@ -91,7 +92,7 @@ export const MainContent = () => {
       })
     );
     return columns;
-  }, [defaultLanguageTags, languageDisplayName]);
+  }, [defaultLanguageTags, languageDisplayName, t]);
 
   const table = useReactTable({
     ...selection.options,

--- a/packages/cms-editor/src/translation/cms-editor/de.json
+++ b/packages/cms-editor/src/translation/cms-editor/de.json
@@ -68,6 +68,7 @@
   "value": {
     "delete": "Wert löschen",
     "lastValue": "Der letzte Wert kann nicht gelöscht werden",
-    "noValue": "[kein Wert]"
+    "noValue": "[kein Wert]",
+    "openFile": "Datei öffnen"
   }
 }

--- a/packages/cms-editor/src/translation/cms-editor/en.json
+++ b/packages/cms-editor/src/translation/cms-editor/en.json
@@ -68,6 +68,7 @@
   "value": {
     "delete": "Delete value",
     "lastValue": "The last value cannot be deleted",
-    "noValue": "[no value]"
+    "noValue": "[no value]",
+    "openFile": "Open File"
   }
 }

--- a/packages/cms-editor/src/translation/cms-editor/ja.json
+++ b/packages/cms-editor/src/translation/cms-editor/ja.json
@@ -67,6 +67,7 @@
   "value": {
     "delete": "",
     "lastValue": "",
-    "noValue": ""
+    "noValue": "",
+    "openFile": ""
   }
 }

--- a/packages/protocol/src/editor.ts
+++ b/packages/protocol/src/editor.ts
@@ -7,7 +7,7 @@
  */
 
 export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
-export type CmsDataObject = CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject;
+export type CmsDataObject = CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject | CmsReadFileDataObject;
 
 export interface CMS {
   cmsActionArgs: CmsActionArgs;
@@ -75,12 +75,21 @@ export interface MapStringString {
 }
 export interface CmsData {
   context: CmsEditorDataContext;
-  data: (CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject)[];
+  data: (CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject | CmsReadFileDataObject)[];
   helpUrl: string;
 }
 export interface CmsFolderDataObject {
   type: ContentObjectType;
   uri: string;
+}
+export interface CmsReadFileDataObject {
+  fileExtension: string;
+  type: ContentObjectType;
+  uri: string;
+  values: MapStringBoolean;
+}
+export interface MapStringBoolean {
+  [k: string]: boolean;
 }
 export interface CmsDataArgs {
   context: CmsEditorDataContext;

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -12,22 +12,21 @@ test.describe('add', () => {
   test('string', async () => {
     await editor.main.control.add.addString('TestContentObject', '/A/TestNamespace', { English: 'TestValue' });
     await editor.main.table.row(0).expectToBeSelected();
-    await editor.main.table.row(0).expectToHaveColumns(['/A/TestNamespace/TestContentObject'], ['TestValue']);
-    await editor.detail.expectToHaveValues('/A/TestNamespace/TestContentObject', { English: 'TestValue', German: '' });
+    await editor.main.table.row(0).expectToHaveStringColumns(['/A/TestNamespace/TestContentObject'], ['TestValue']);
+    await editor.detail.expectToHaveStringValues('/A/TestNamespace/TestContentObject', { English: 'TestValue', German: '' });
 
     await editor.main.control.add.addString('TestContentObject', '/Z/TestNamespace', { English: 'TestValue' });
     await editor.main.table.locator.locator('../..').evaluate((el: HTMLElement) => (el.scrollTop = el.scrollHeight));
     await editor.main.table.row(-1).expectToBeSelected();
-    await editor.main.table.row(-1).expectToHaveColumns(['/Z/TestNamespace/TestContentObject'], ['TestValue']);
-    await editor.detail.expectToHaveValues('/Z/TestNamespace/TestContentObject', { English: 'TestValue', German: '' });
+    await editor.main.table.row(-1).expectToHaveStringColumns(['/Z/TestNamespace/TestContentObject'], ['TestValue']);
+    await editor.detail.expectToHaveStringValues('/Z/TestNamespace/TestContentObject', { English: 'TestValue', German: '' });
   });
 
   test('file', async () => {
     await editor.main.control.add.addFile('TestContentObject', '/A/TestNamespace', { English: path.join('test-files', 'TestFile.txt') });
     await editor.main.table.row(0).expectToBeSelected();
-    await editor.main.table.row(0).expectToHaveColumns(['/A/TestNamespace/TestContentObject'], ['TestContent']);
-    await editor.detail.expectToHaveValues('/A/TestNamespace/TestContentObject', { English: 'TestContent\n', German: '' });
-    await expect(editor.detail.value('English').filePicker).toBeVisible();
+    await editor.main.table.row(0).expectToHaveFileColumns('/A/TestNamespace/TestContentObject', [true]);
+    await editor.detail.expectToHaveFileValues('/A/TestNamespace/TestContentObject', { English: true, German: false });
   });
 });
 
@@ -76,20 +75,23 @@ test('default values', async () => {
 
 test('type', async () => {
   const add = editor.main.control.add;
+  const englishValue = add.value('English');
 
   await add.trigger.click();
-  await expect(add.value('English').filePicker).toBeHidden();
+  await expect(englishValue.textbox.locator).toBeVisible();
+  await expect(englishValue.filePicker).toBeHidden();
 
   await add.type.select('File');
-  await expect(add.value('English').filePicker).toBeVisible();
-  await expect(add.value('English').textbox.locator).toBeDisabled();
-  await expect(add.value('English').textbox.locator).toHaveValue('');
-  await add.value('English').textbox.expectToHavePlaceholder('[no value]');
+  await expect(englishValue.textbox.locator).toBeHidden();
+  await expect(englishValue.filePicker).toBeVisible();
+
+  await englishValue.selectFile(path.join('test-files', 'TestFile.txt'));
+  await expect(englishValue.fileButton).toBeHidden();
 
   await add.type.select('String');
-  await expect(add.value('English').filePicker).toBeHidden();
-  await expect(add.value('English').textbox.locator).toHaveValue('');
-  await add.value('English').textbox.expectToHaveNoPlaceholder();
+  await expect(englishValue.textbox.locator).toBeVisible();
+  await expect(englishValue.textbox.locator).toHaveValue('');
+  await expect(englishValue.filePicker).toBeHidden();
 });
 
 test('file extension', async ({ page }) => {

--- a/playwright/tests/integration/mock/delete.spec.ts
+++ b/playwright/tests/integration/mock/delete.spec.ts
@@ -16,30 +16,30 @@ test('delete', async () => {
   await firstRow.locator.click();
   await expect(deleteButton).toBeEnabled();
 
-  await firstRow.expectToHaveColumns(['/Dialogs/agileBPM/define_WF/AddTask'], ['Add a task to the sequence']);
-  await editor.detail.expectToHaveValues('/Dialogs/agileBPM/define_WF/AddTask', { English: 'Add a task to the sequence' });
+  await firstRow.expectToHaveStringColumns(['/Dialogs/agileBPM/define_WF/AddTask'], ['Add a task to the sequence']);
+  await editor.detail.expectToHaveStringValues('/Dialogs/agileBPM/define_WF/AddTask', { English: 'Add a task to the sequence' });
   await deleteButton.click();
   await firstRow.expectToBeSelected();
-  await firstRow.expectToHaveColumns(['/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks'], ['Workflow Tasks']);
-  await editor.detail.expectToHaveValues('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks', { English: 'Workflow Tasks' });
+  await firstRow.expectToHaveStringColumns(['/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks'], ['Workflow Tasks']);
+  await editor.detail.expectToHaveStringValues('/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks', { English: 'Workflow Tasks' });
 
   await firstRow.locator.click();
   await editor.page.keyboard.press('ArrowUp');
   const lastRow = editor.main.table.row(-1);
-  await lastRow.expectToHaveColumns(['/Files/TextFile'], ['Content']);
-  await editor.detail.expectToHaveValues('/Files/TextFile', { English: 'Content' });
+  await lastRow.expectToHaveFileColumns('/Files/TextFile', [true]);
+  await editor.detail.expectToHaveFileValues('/Files/TextFile', { English: true });
   await deleteButton.click();
   await lastRow.expectToBeSelected();
-  await lastRow.expectToHaveColumns(['/Dialogs/trigger/selectParkingLot'], ['Select parking lot']);
-  await editor.detail.expectToHaveValues('/Dialogs/trigger/selectParkingLot', { English: 'Select parking lot' });
+  await lastRow.expectToHaveStringColumns(['/Dialogs/trigger/selectParkingLot'], ['Select parking lot']);
+  await editor.detail.expectToHaveStringValues('/Dialogs/trigger/selectParkingLot', { English: 'Select parking lot' });
 });
 
 test('keyboard', async () => {
   const row = editor.main.table.row(1);
-  await row.expectToHaveColumns(['/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks'], ['Workflow Tasks']);
+  await row.expectToHaveStringColumns(['/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks'], ['Workflow Tasks']);
   await editor.page.keyboard.press('Delete');
-  await row.expectToHaveColumns(['/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks'], ['Workflow Tasks']);
+  await row.expectToHaveStringColumns(['/Dialogs/agileBPM/define_WF/AdhocWorkflowTasks'], ['Workflow Tasks']);
   await row.locator.click();
   await editor.page.keyboard.press('Delete');
-  await row.expectToHaveColumns(['/Dialogs/agileBPM/define_WF/Case'], ['Case']);
+  await row.expectToHaveStringColumns(['/Dialogs/agileBPM/define_WF/Case'], ['Case']);
 });

--- a/playwright/tests/integration/mock/detail.spec.ts
+++ b/playwright/tests/integration/mock/detail.spec.ts
@@ -81,19 +81,17 @@ test.describe('delete value', () => {
 
     await englishValue.selectFile(path.join('test-files', 'TestFile.txt'));
 
-    await expect(englishValue.textbox.locator).toHaveValue('TestContent\n');
-    await englishValue.textbox.expectToHaveNoPlaceholder();
+    await expect(englishValue.fileButton).toBeVisible();
     const fileName = await englishValue.filePicker.evaluate((input: HTMLInputElement) => input.files?.[0]?.name);
     expect(fileName).toEqual('TestFile.txt');
-    await expect(row.column(1).value(0)).toHaveText('TestContent');
+    await expect(row.column(1).value(0).getByRole('button')).toBeVisible();
 
     await englishValue.delete.click();
 
-    await expect(englishValue.textbox.locator).toHaveValue('');
-    await englishValue.textbox.expectToHavePlaceholder('[no value]');
+    await expect(englishValue.fileButton).toBeHidden();
     const fileCount = await englishValue.filePicker.evaluate((input: HTMLInputElement) => input.files?.length);
     expect(fileCount).toEqual(0);
-    await expect(row.column(1).value(0)).toHaveText('');
+    await expect(row.column(1).value(0).getByRole('button')).toBeHidden();
   });
 });
 
@@ -116,15 +114,13 @@ test.describe('update value', () => {
     await editor.main.table.locator.focus();
     await editor.page.keyboard.press('ArrowUp');
 
-    const row = editor.main.table.row(-1);
-
     const englishValue = editor.detail.value('English');
 
-    await expect(englishValue.textbox.locator).toHaveValue('Content');
-    await expect(row.column(1).value(0)).toHaveText('Content');
+    const fileCount = await englishValue.filePicker.evaluate((input: HTMLInputElement) => input.files?.length);
+    expect(fileCount).toEqual(0);
 
     await englishValue.selectFile(path.join('test-files', 'TestFile.txt'));
-    await expect(englishValue.textbox.locator).toHaveValue('TestContent\n');
-    await expect(row.column(1).value(0)).toHaveText('TestContent');
+    const fileName = await englishValue.filePicker.evaluate((input: HTMLInputElement) => input.files?.[0]?.name);
+    expect(fileName).toEqual('TestFile.txt');
   });
 });

--- a/playwright/tests/integration/read.spec.ts
+++ b/playwright/tests/integration/read.spec.ts
@@ -6,14 +6,14 @@ test('load data', async ({ page }) => {
   await expect(editor.main.table.rows).toHaveCount(3);
 
   await editor.main.table.row(0).locator.click();
-  await editor.main.table.row(0).expectToHaveColumns(['/files/File'], ['Content']);
-  await editor.detail.expectToHaveValues('/files/File', { English: 'Content\n', German: '' });
+  await editor.main.table.row(0).expectToHaveFileColumns('/files/File', [true]);
+  await editor.detail.expectToHaveFileValues('/files/File', { English: true, German: false });
 
   await editor.main.table.row(1).locator.click();
-  await editor.main.table.row(1).expectToHaveColumns(['/folder/stringOne'], ['valueOne']);
-  await editor.detail.expectToHaveValues('/folder/stringOne', { English: 'valueOne', German: 'wertEins' });
+  await editor.main.table.row(1).expectToHaveStringColumns(['/folder/stringOne'], ['valueOne']);
+  await editor.detail.expectToHaveStringValues('/folder/stringOne', { English: 'valueOne', German: 'wertEins' });
 
   await editor.main.table.row(2).locator.click();
-  await editor.main.table.row(2).expectToHaveColumns(['/folder/stringTwo'], ['valueTwo']);
-  await editor.detail.expectToHaveValues('/folder/stringTwo', { English: 'valueTwo', German: '' });
+  await editor.main.table.row(2).expectToHaveStringColumns(['/folder/stringTwo'], ['valueTwo']);
+  await editor.detail.expectToHaveStringValues('/folder/stringTwo', { English: 'valueTwo', German: '' });
 });

--- a/playwright/tests/integration/write.spec.ts
+++ b/playwright/tests/integration/write.spec.ts
@@ -23,7 +23,7 @@ test('save data', async () => {
   await editor.page.reload();
 
   await editor.main.table.row(0).locator.click();
-  await editor.detail.expectToHaveValues('/TestNamespace/TestContentObject', { Afrikaans: 'AfrikaansValue', Akan: '', Albanian: '' });
+  await editor.detail.expectToHaveStringValues('/TestNamespace/TestContentObject', { Afrikaans: 'AfrikaansValue', Akan: '', Albanian: '' });
   await editor.detail.value('Akan').textbox.expectToHavePlaceholder('[no value]');
   await editor.detail.value('Albanian').textbox.expectToHavePlaceholder('[no value]');
 
@@ -33,7 +33,7 @@ test('save data', async () => {
   await editor.page.reload();
 
   await editor.main.table.row(0).locator.click();
-  await editor.detail.expectToHaveValues('/TestNamespace/TestContentObject', { Afrikaans: '', Akan: 'AkanValue', Albanian: 'AlbanianValue' });
+  await editor.detail.expectToHaveStringValues('/TestNamespace/TestContentObject', { Afrikaans: '', Akan: 'AkanValue', Albanian: 'AlbanianValue' });
   await editor.detail.value('Afrikaans').textbox.expectToHavePlaceholder('[no value]');
 
   await editor.main.control.languageTool.trigger.click();
@@ -66,7 +66,7 @@ test('add file', async () => {
   await editor.page.reload();
 
   await editor.main.table.row(0).locator.click();
-  await editor.detail.expectToHaveValues('/TestNamespace/TestFile', { Afrikaans: 'TestContent\n' });
+  await editor.detail.expectToHaveFileValues('/TestNamespace/TestFile', { Afrikaans: true });
   await expect(editor.detail.value('Afrikaans').filePicker).toBeVisible();
   await expect(editor.detail.value('Afrikaans').filePicker).toHaveAttribute('accept', '.txt');
 });

--- a/playwright/tests/pageobjects/components/CmsValueField.ts
+++ b/playwright/tests/pageobjects/components/CmsValueField.ts
@@ -7,6 +7,7 @@ export class CmsValueField {
   readonly label: Locator;
   readonly delete: Locator;
   readonly filePicker: Locator;
+  readonly fileButton: Locator;
   readonly textbox: Textbox;
 
   constructor(page: Page, parent: Locator, options?: { label?: string; nth?: number }) {
@@ -21,6 +22,7 @@ export class CmsValueField {
     this.label = this.locator.locator('label');
     this.delete = this.locator.getByRole('button', { name: 'Delete value' });
     this.filePicker = this.locator.locator('input[type=file]');
+    this.fileButton = this.locator.getByRole('button', { name: 'Open File' });
     this.textbox = new Textbox(this.locator);
   }
 

--- a/playwright/tests/pageobjects/detail/DetailPanel.ts
+++ b/playwright/tests/pageobjects/detail/DetailPanel.ts
@@ -24,10 +24,23 @@ export class DetailPanel {
     return new CmsValueField(this.page, this.locator, { label });
   }
 
-  async expectToHaveValues(uri: string, values: Record<string, string>) {
+  async expectToHaveStringValues(uri: string, values: Record<string, string>) {
     await expect(this.uri.locator).toHaveValue(uri);
     for (const [language, value] of Object.entries(values)) {
       await expect(this.value(language).textbox.locator).toHaveValue(value);
+    }
+  }
+
+  async expectToHaveFileValues(uri: string, values: Record<string, boolean>) {
+    await expect(this.uri.locator).toHaveValue(uri);
+    for (const [language, value] of Object.entries(values)) {
+      await expect(this.value(language).filePicker).toBeVisible();
+      const button = this.value(language).fileButton;
+      if (value) {
+        await expect(button).toBeVisible();
+      } else {
+        await expect(button).toBeHidden();
+      }
     }
   }
 }

--- a/playwright/tests/pageobjects/main/Table.ts
+++ b/playwright/tests/pageobjects/main/Table.ts
@@ -50,7 +50,7 @@ export class Table {
 
   async expectToHaveRows(...rows: Array<Array<Array<string>>>) {
     for (let i = 0; i < rows.length; i++) {
-      await this.row(i).expectToHaveColumns(...rows[i]);
+      await this.row(i).expectToHaveStringColumns(...rows[i]);
     }
   }
 }
@@ -107,9 +107,16 @@ export class Row {
     await expect(this.expandCollapseButton).toHaveAttribute('data-state', 'collapsed');
   }
 
-  async expectToHaveColumns(...values: Array<Array<string>>) {
+  async expectToHaveStringColumns(...values: Array<Array<string>>) {
     for (let i = 0; i < values.length; i++) {
-      await this.column(i).expectToHaveValues(...values[i]);
+      await this.column(i).expectToHaveStringValues(...values[i]);
+    }
+  }
+
+  async expectToHaveFileColumns(uri: string, ...values: Array<Array<boolean>>) {
+    await expect(this.column(0).value(0)).toHaveText(uri);
+    for (let i = 0; i < values.length; i++) {
+      await this.column(i + 1).expectToHaveFileValues(uri, ...values[i]);
     }
   }
 }
@@ -127,9 +134,20 @@ export class Cell {
     return this.values.nth(index);
   }
 
-  async expectToHaveValues(...values: Array<string>) {
+  async expectToHaveStringValues(...values: Array<string>) {
     for (let i = 0; i < values.length; i++) {
       await expect(this.values.nth(i)).toHaveText(values[i]);
+    }
+  }
+
+  async expectToHaveFileValues(uri: string, ...values: Array<boolean>) {
+    for (let i = 0; i < values.length; i++) {
+      const button = this.values.nth(i).getByRole('button');
+      if (values[i]) {
+        await expect(button).toBeVisible();
+      } else {
+        await expect(button).toBeHidden();
+      }
     }
   }
 }


### PR DESCRIPTION
[XIVY-16203 display buttons instead of file values](https://github.com/axonivy/cms-editor/commit/9d35af0a7096755dadbb65a2534bb281aa44694b)

The LSP no longer returns the values for Content Objects of type `FILE`.
Instead, it returns a boolean indicating whether a value exists.
This boolean is used to determine whether to display a button that:
- indicates whether a value exists.
- opens the file (not implemented yet).

[XIVY-16203 test open file button](https://github.com/axonivy/cms-editor/commit/d782fcf31a151ba24e24e1d569e933b731d6de00)