### PR TITLE
Fix weblate: supply first JA values

### DIFF
--- a/packages/cms-editor/src/translation/cms-editor/ja.json
+++ b/packages/cms-editor/src/translation/cms-editor/ja.json
@@ -1,0 +1,9 @@
+{
+  "common": {
+    "hotkey": {
+      "focusInscription": "焦点の徴候({{hotkey}})",
+      "focusMain": "焦点の本管({{hotkey}})",
+      "focusToolbar": "焦点のツールバー({{hotkey}})"
+    }
+  }
+}


### PR DESCRIPTION
weblate is currently stuck, since the JA file without any real values assigned was removed while changes were contributed upon it.
This manually onboards Weblate changes again, without re-introducing the empty values that prevent EN defaults to be shown.

![weblate-cms-conflict](https://github.com/user-attachments/assets/17e344da-04bd-4f32-99fa-e1e8a9cdd911)
