### PR TITLE
XIVY-16203 use backend provided links

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -1,5 +1,6 @@
 import {
   isCmsFileDataObject,
+  isCmsReadFileDataObject,
   isCmsStringDataObject,
   isCmsValueDataObject,
   removeValue,
@@ -56,7 +57,11 @@ export class CmsClientMock implements Client {
   }
 
   read(args: CmsReadArgs): Promise<CmsDataObject> {
-    return Promise.resolve(this.findContentObject(args.uri) ?? ({} as CmsDataObject));
+    const co = this.findContentObject(args.uri);
+    if (isCmsReadFileDataObject(co)) {
+      co.values = Object.fromEntries(Object.keys(co.values).map(key => [key, `http://localhost:8080/test/cm/test$1${co.uri}?l=${key}`]));
+    }
+    return Promise.resolve(co ?? ({} as CmsDataObject));
   }
 
   updateStringValue = (args: CmsUpdateStringValueArgs): void => {

--- a/integrations/standalone/src/mock/data.ts
+++ b/integrations/standalone/src/mock/data.ts
@@ -198,6 +198,5 @@ export const contentObjects: CmsData = {
     { uri: '/Files', type: 'FOLDER' },
     { uri: '/Files/TextFile', type: 'FILE', values: { de: true, en: true }, fileExtension: 'txt' }
   ],
-  helpUrl: 'https://dev.axonivy.com',
-  cmUrl: 'http://localhost:8080/cm'
+  helpUrl: 'https://dev.axonivy.com'
 };

--- a/packages/cms-editor/src/CmsEditor.tsx
+++ b/packages/cms-editor/src/CmsEditor.tsx
@@ -69,8 +69,7 @@ function CmsEditor(props: EditorProps) {
         setDetail,
         defaultLanguageTags,
         setDefaultLanguageTags,
-        languageDisplayName,
-        cmUrl: data.cmUrl
+        languageDisplayName
       }}
     >
       <ResizablePanelGroup direction='horizontal'>

--- a/packages/cms-editor/src/components/FileValueField.tsx
+++ b/packages/cms-editor/src/components/FileValueField.tsx
@@ -36,7 +36,7 @@ export const FileValueField = ({ updateValue, deleteValue, setFileExtension, all
     }
   };
 
-  const value = baseProps.contentObject.values[baseProps.language.value];
+  const url = baseProps.contentObject.values[baseProps.language.value];
   const openUrl = useAction('openUrl');
 
   return (
@@ -49,11 +49,11 @@ export const FileValueField = ({ updateValue, deleteValue, setFileExtension, all
           disabled={baseProps.disabled}
           ref={inputRef}
         />
-        {allowOpenFile && value && (
+        {allowOpenFile && url && (
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button icon={IvyIcons.File} aria-label={t('value.openFile')} onClick={() => openUrl(value as string)} />
+                <Button icon={IvyIcons.File} aria-label={t('value.openFile')} onClick={() => openUrl(url as string)} />
               </TooltipTrigger>
               <TooltipContent>{t('value.openFile')}</TooltipContent>
             </Tooltip>

--- a/packages/cms-editor/src/components/FileValueField.tsx
+++ b/packages/cms-editor/src/components/FileValueField.tsx
@@ -1,13 +1,12 @@
-import type { CmsFileDataObject } from '@axonivy/cms-editor-protocol';
+import type { CmsFileDataObject, CmsReadFileDataObject } from '@axonivy/cms-editor-protocol';
 import { Button, Flex, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@axonivy/ui-components';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useAppContext } from '../context/AppContext';
 import { useAction } from '../protocol/use-action';
 import { BaseValueField, type BaseValueFieldProps } from './BaseValueField';
 
-type FileValueFieldProps = BaseValueFieldProps<CmsFileDataObject> & {
+type FileValueFieldProps = BaseValueFieldProps<CmsFileDataObject | CmsReadFileDataObject> & {
   updateValue: (languageTag: string, value: Array<number>) => void;
   deleteValue: (languageTag: string) => void;
   setFileExtension?: (fileExtension?: string) => void;
@@ -16,7 +15,6 @@ type FileValueFieldProps = BaseValueFieldProps<CmsFileDataObject> & {
 
 export const FileValueField = ({ updateValue, deleteValue, setFileExtension, allowOpenFile, ...baseProps }: FileValueFieldProps) => {
   const { t } = useTranslation();
-  const { cmUrl } = useAppContext();
 
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -38,6 +36,7 @@ export const FileValueField = ({ updateValue, deleteValue, setFileExtension, all
     }
   };
 
+  const value = baseProps.contentObject.values[baseProps.language.value];
   const openUrl = useAction('openUrl');
 
   return (
@@ -50,15 +49,11 @@ export const FileValueField = ({ updateValue, deleteValue, setFileExtension, all
           disabled={baseProps.disabled}
           ref={inputRef}
         />
-        {allowOpenFile && baseProps.contentObject.values[baseProps.language.value] && (
+        {allowOpenFile && value && (
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  icon={IvyIcons.File}
-                  aria-label={t('value.openFile')}
-                  onClick={() => openUrl(`${cmUrl}${baseProps.contentObject.uri}?l=${baseProps.language.value}`)}
-                />
+                <Button icon={IvyIcons.File} aria-label={t('value.openFile')} onClick={() => openUrl(value as string)} />
               </TooltipTrigger>
               <TooltipContent>{t('value.openFile')}</TooltipContent>
             </Tooltip>

--- a/packages/cms-editor/src/context/AppContext.tsx
+++ b/packages/cms-editor/src/context/AppContext.tsx
@@ -12,7 +12,6 @@ type AppContext = {
   defaultLanguageTags: Array<string>;
   setDefaultLanguageTags: (languageTags: Array<string>) => void;
   languageDisplayName: Intl.DisplayNames;
-  cmUrl: string;
 };
 
 const appContext = createContext<AppContext>({
@@ -24,8 +23,7 @@ const appContext = createContext<AppContext>({
   setDetail: () => {},
   defaultLanguageTags: [],
   setDefaultLanguageTags: () => {},
-  languageDisplayName: new Intl.DisplayNames(undefined, { type: 'language' }),
-  cmUrl: ''
+  languageDisplayName: new Intl.DisplayNames(undefined, { type: 'language' })
 });
 
 export const AppProvider = appContext.Provider;

--- a/packages/cms-editor/src/context/test-utils/test-utils.tsx
+++ b/packages/cms-editor/src/context/test-utils/test-utils.tsx
@@ -28,7 +28,6 @@ type ContextHelperProps = {
     defaultLanguageTags?: Array<string>;
     setDefaultLanguageTags?: (languageTags: Array<string>) => void;
     languageDisplayName?: Intl.DisplayNames;
-    cmUrl?: string;
   };
 };
 
@@ -63,8 +62,7 @@ const ContextHelper = ({
     setDetail: appContext?.setDetail ?? (() => {}),
     defaultLanguageTags: appContext?.defaultLanguageTags ?? [],
     setDefaultLanguageTags: appContext?.setDefaultLanguageTags ?? (() => {}),
-    languageDisplayName: appContext?.languageDisplayName ?? ({} as Intl.DisplayNames),
-    cmUrl: appContext?.cmUrl ?? ''
+    languageDisplayName: appContext?.languageDisplayName ?? ({} as Intl.DisplayNames)
   };
 
   initTranslation(clientLanguage);

--- a/packages/cms-editor/src/utils/cms-utils.ts
+++ b/packages/cms-editor/src/utils/cms-utils.ts
@@ -3,6 +3,7 @@ import type {
   CmsDataObjectValues,
   CmsFileDataObject,
   CmsFolderDataObject,
+  CmsReadFileDataObject,
   CmsStringDataObject
 } from '@axonivy/cms-editor-protocol';
 
@@ -15,6 +16,7 @@ export const removeValue = (values: CmsDataObjectValues, languageTag: string): C
 export const isCmsFolderDataObject = (object?: CmsDataObject): object is CmsFolderDataObject => object?.type === 'FOLDER';
 export const isCmsStringDataObject = (object?: CmsDataObject): object is CmsStringDataObject => object?.type === 'STRING';
 export const isCmsFileDataObject = (object?: CmsDataObject): object is CmsFileDataObject => object?.type === 'FILE';
+export const isCmsReadFileDataObject = (object?: CmsDataObject): object is CmsReadFileDataObject => object?.type === 'FILE';
 
 export type CmsValueDataObject = CmsStringDataObject | CmsFileDataObject;
 export const isCmsValueDataObject = (object?: CmsDataObject): object is CmsValueDataObject =>

--- a/packages/protocol/src/editor.ts
+++ b/packages/protocol/src/editor.ts
@@ -7,7 +7,12 @@
  */
 
 export type ContentObjectType = ("STRING" | "FILE" | "FOLDER")
-export type CmsDataObject = CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject | CmsReadFileDataObject;
+export type CmsDataObject =
+  | CmsFolderDataObject
+  | CmsStringDataObject
+  | CmsFileDataObject
+  | CmsDataFileDataObject
+  | CmsReadFileDataObject;
 
 export interface CMS {
   cmsActionArgs: CmsActionArgs;
@@ -74,16 +79,21 @@ export interface MapStringString {
   [k: string]: string;
 }
 export interface CmsData {
-  cmUrl: string;
   context: CmsEditorDataContext;
-  data: (CmsFolderDataObject | CmsStringDataObject | CmsFileDataObject | CmsReadFileDataObject)[];
+  data: (
+    | CmsFolderDataObject
+    | CmsStringDataObject
+    | CmsFileDataObject
+    | CmsDataFileDataObject
+    | CmsReadFileDataObject
+  )[];
   helpUrl: string;
 }
 export interface CmsFolderDataObject {
   type: ContentObjectType;
   uri: string;
 }
-export interface CmsReadFileDataObject {
+export interface CmsDataFileDataObject {
   fileExtension: string;
   type: ContentObjectType;
   uri: string;
@@ -91,6 +101,15 @@ export interface CmsReadFileDataObject {
 }
 export interface MapStringBoolean {
   [k: string]: boolean;
+}
+export interface CmsReadFileDataObject {
+  fileExtension: string;
+  type: ContentObjectType;
+  uri: string;
+  values: MapStringURI;
+}
+export interface MapStringURI {
+  [k: string]: string;
 }
 export interface CmsDataArgs {
   context: CmsEditorDataContext;

--- a/playwright/tests/integration/mock/detail.spec.ts
+++ b/playwright/tests/integration/mock/detail.spec.ts
@@ -132,10 +132,10 @@ test('openFile', async () => {
   const msg0 = editor.consoleLog();
   await editor.detail.value('English').fileButton.click();
   expect(await msg0).toContain('openUrl');
-  expect(await msg0).toContain('http://localhost:8080/cm/Files/TextFile?l=en');
+  expect(await msg0).toContain('http://localhost:8080/test/cm/test$1/Files/TextFile?l=en');
 
   const msg1 = editor.consoleLog();
   await editor.detail.value('German').fileButton.click();
   expect(await msg1).toContain('openUrl');
-  expect(await msg1).toContain('http://localhost:8080/cm/Files/TextFile?l=de');
+  expect(await msg1).toContain('http://localhost:8080/test/cm/test$1/Files/TextFile?l=de');
 });


### PR DESCRIPTION
I changed my mind. Let the backend provide a link to open the file of each value.
There are more moving parts to these links than I expected.
This also makes the backend the single source of truth for how these links should look; the frontend doesn't need to know or care about them.