### PR TITLE
XIVY-16203 hide delete value button

### DIFF
--- a/packages/cms-editor/src/components/BaseValueField.test.tsx
+++ b/packages/cms-editor/src/components/BaseValueField.test.tsx
@@ -6,7 +6,7 @@ import { BaseValueField } from './BaseValueField';
 
 test('state', () => {
   const view = renderBaseValueField({});
-  expect(screen.getByRole('button')).toBeDisabled();
+  expect(screen.queryByRole('button')).not.toBeInTheDocument();
 
   view.rerenderWithValues({ en: '' });
   expect(screen.getByRole('button')).toBeEnabled();

--- a/packages/cms-editor/src/components/BaseValueField.tsx
+++ b/packages/cms-editor/src/components/BaseValueField.tsx
@@ -44,14 +44,14 @@ export const BaseValueField = ({
     <BasicField
       label={language.label}
       control={
-        readonly ? null : (
+        readonly || !isValuePresent ? null : (
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   icon={IvyIcons.Trash}
                   onClick={() => deleteValue(language.value)}
-                  disabled={disabled || disabledDelete || !isValuePresent}
+                  disabled={disabled || disabledDelete}
                   aria-label={t('value.delete')}
                 />
               </TooltipTrigger>

--- a/playwright/tests/integration/mock/detail.spec.ts
+++ b/playwright/tests/integration/mock/detail.spec.ts
@@ -53,9 +53,7 @@ test.describe('delete value', () => {
 
     await englishValue.delete.click();
 
-    await expect(englishValue.delete).toBeDisabled();
-    await englishValue.delete.hover();
-    await expect(editor.page.getByRole('tooltip')).toHaveText('Delete value');
+    await expect(englishValue.delete).toBeHidden();
     await expect(englishValue.textbox.locator).toHaveValue('');
     await englishValue.textbox.expectToHavePlaceholder('[no value]');
     await expect(row.column(1).value(0)).toHaveText('');
@@ -138,4 +136,28 @@ test('openFile', async () => {
   await editor.detail.value('German').fileButton.click();
   expect(await msg1).toContain('openUrl');
   expect(await msg1).toContain('http://localhost:8080/test/cm/test$1/Files/TextFile?l=de');
+});
+
+test('deleteValueButtonState', async () => {
+  await editor.main.table.row(0).locator.click();
+  const englishValue = editor.detail.value('English');
+  const germanValue = editor.detail.value('German');
+
+  await expect(englishValue.delete).toBeVisible();
+  await expect(englishValue.delete).toBeEnabled();
+  await englishValue.delete.hover();
+  await expect(editor.page.getByRole('tooltip')).toHaveText('Delete value');
+
+  await expect(germanValue.delete).toBeVisible();
+  await expect(germanValue.delete).toBeEnabled();
+  await germanValue.delete.hover();
+  await expect(editor.page.getByRole('tooltip')).toHaveText('Delete value');
+
+  await englishValue.delete.click();
+  await expect(englishValue.delete).toBeHidden();
+
+  await expect(germanValue.delete).toBeVisible();
+  await expect(germanValue.delete).toBeDisabled();
+  await germanValue.delete.hover();
+  await expect(editor.page.getByRole('tooltip')).toHaveText('The last value cannot be deleted');
 });


### PR DESCRIPTION
Hide the "Delete Value" button if no value is present instead of just disabling it.

Requested by Anaïs