### PR TITLE
XIVY-16203 fix: timing of read invalidation

### DIFF
--- a/integrations/standalone/src/mock/cms-client-mock.ts
+++ b/integrations/standalone/src/mock/cms-client-mock.ts
@@ -80,8 +80,9 @@ export class CmsClientMock implements Client {
     this.updateValue(args, isCmsStringDataObject);
   };
 
-  updateFileValue = (args: CmsUpdateFileValueArgs): void => {
+  updateFileValue = (args: CmsUpdateFileValueArgs): Promise<Void> => {
     this.updateValue(args, isCmsFileDataObject);
+    return Promise.resolve({});
   };
 
   private updateValue<T extends CmsValueDataObject>(args: CmsUpdateValueArgs, typeCheck: (co?: CmsDataObject) => co is T) {

--- a/packages/cms-editor/src/protocol/client-json-rpc.ts
+++ b/packages/cms-editor/src/protocol/client-json-rpc.ts
@@ -41,8 +41,8 @@ export class ClientJsonRpc extends BaseRpcClient implements Client {
     this.sendRequest('updateStringValue', args);
   };
 
-  updateFileValue = (args: CmsUpdateFileValueArgs): void => {
-    this.sendRequest('updateFileValue', args);
+  updateFileValue = (args: CmsUpdateFileValueArgs): Promise<Void> => {
+    return this.sendRequest('updateFileValue', args);
   };
 
   deleteValue(args: CmsDeleteValueArgs): void {

--- a/packages/protocol/src/types.ts
+++ b/packages/protocol/src/types.ts
@@ -34,7 +34,7 @@ export interface Client {
   createFile(args: CmsCreateFileArgs): Promise<Void>;
   read(args: CmsReadArgs): Promise<CmsDataObject>;
   updateStringValue(args: CmsUpdateStringValueArgs): void;
-  updateFileValue(args: CmsUpdateFileValueArgs): void;
+  updateFileValue(args: CmsUpdateFileValueArgs): Promise<Void>;
   deleteValue(args: CmsDeleteValueArgs): void;
   delete(args: CmsDeleteArgs): void;
   addLocales(args: CmsAddLocalesArgs): void;


### PR DESCRIPTION
The `onSuccess` method was not waiting for the `updateFileValue` request to complete because it did not return a promise.
