### PR TITLE
XIVY-17160 improve design of files in table

### DIFF
--- a/packages/cms-editor/src/main/MainContent.tsx
+++ b/packages/cms-editor/src/main/MainContent.tsx
@@ -18,6 +18,7 @@ import {
   useTableSelect,
   useTableSort
 } from '@axonivy/ui-components';
+import { IvyIcons } from '@axonivy/ui-icons';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { flexRender, getCoreRowModel, useReactTable, type ColumnDef } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
@@ -26,7 +27,7 @@ import { useTranslation } from 'react-i18next';
 import { useAppContext } from '../context/AppContext';
 import { useClient } from '../protocol/ClientContextProvider';
 import { useQueryKeys } from '../query/query-client';
-import { fileIcon, isCmsDataFileDataObject, isCmsValueDataObject, type CmsValueDataObject } from '../utils/cms-utils';
+import { fileIcon, fileName, isCmsDataFileDataObject, isCmsValueDataObject, type CmsValueDataObject } from '../utils/cms-utils';
 import { useKnownHotkeys } from '../utils/hotkeys';
 import './MainContent.css';
 import { MainControl } from './control/MainControl';
@@ -68,7 +69,12 @@ export const MainContent = () => {
       {
         accessorKey: 'uri',
         header: ({ column }) => <SortableHeader column={column} name={t('common.label.path')} />,
-        cell: cell => <span>{cell.getValue()}</span>,
+        cell: cell => (
+          <Flex alignItems='center' gap={1}>
+            {<IvyIcon icon={isCmsDataFileDataObject(cell.row.original) ? fileIcon(cell.row.original.mimeType) : IvyIcons.Quote} />}
+            <span>{cell.getValue()}</span>
+          </Flex>
+        ),
         minSize: 200,
         size: 500,
         maxSize: 1000
@@ -77,15 +83,7 @@ export const MainContent = () => {
     toLanguages(defaultLanguageTags, languageDisplayName).forEach(language =>
       columns.push({
         id: language.value,
-        accessorFn: co =>
-          isCmsDataFileDataObject(co) && co.values[language.value] ? (
-            <Flex alignItems='center' gap={1}>
-              <IvyIcon icon={fileIcon(co.mimeType)} />
-              {`(${co.fileExtension})`}
-            </Flex>
-          ) : (
-            co.values[language.value]
-          ),
+        accessorFn: co => (isCmsDataFileDataObject(co) && co.values[language.value] ? fileName(co) : co.values[language.value]),
         header: ({ column }) => <SortableHeader column={column} name={language.label} />,
         cell: cell => <span>{cell.getValue()}</span>,
         minSize: 200,

--- a/packages/cms-editor/src/utils/cms-utils.test.ts
+++ b/packages/cms-editor/src/utils/cms-utils.test.ts
@@ -1,7 +1,8 @@
-import type { CmsDataObject } from '@axonivy/cms-editor-protocol';
+import type { CmsDataFileDataObject, CmsDataObject } from '@axonivy/cms-editor-protocol';
 import { IvyIcons } from '@axonivy/ui-icons';
 import {
   fileIcon,
+  fileName,
   isCmsDataFileDataObject,
   isCmsFileDataObject,
   isCmsReadFileDataObject,
@@ -76,4 +77,10 @@ test('fileIcon', () => {
   expect(fileIcon('text/plain')).toEqual(IvyIcons.File);
   expect(fileIcon('image/jpeg')).toEqual(IvyIcons.CustomImage);
   expect(fileIcon('image/png')).toEqual(IvyIcons.CustomImage);
+});
+
+test('fileName', () => {
+  expect(fileName({ uri: '/File', fileExtension: '' } as CmsDataFileDataObject)).toEqual('File');
+  expect(fileName({ uri: '/ImageFile', fileExtension: 'png' } as CmsDataFileDataObject)).toEqual('ImageFile.png');
+  expect(fileName({ uri: '/files/TextFile', fileExtension: 'txt' } as CmsDataFileDataObject)).toEqual('TextFile.txt');
 });

--- a/packages/cms-editor/src/utils/cms-utils.ts
+++ b/packages/cms-editor/src/utils/cms-utils.ts
@@ -30,3 +30,5 @@ export const isCmsValueDataObject = (object?: CmsDataObject): object is CmsValue
   isCmsStringDataObject(object) || isCmsFileDataObject(object) || isCmsDataFileDataObject(object) || isCmsReadFileDataObject(object);
 
 export const fileIcon = (mimeType: string) => (mimeType.startsWith('image') ? IvyIcons.CustomImage : IvyIcons.File);
+export const fileName = (co: CmsDataFileDataObject) =>
+  `${co.uri.substring(co.uri.lastIndexOf('/') + 1)}${co.fileExtension ? `.${co.fileExtension}` : ''}`;

--- a/playwright/tests/integration/mock/add.spec.ts
+++ b/playwright/tests/integration/mock/add.spec.ts
@@ -25,7 +25,7 @@ test.describe('add', () => {
   test('file', async () => {
     await editor.main.control.add.addFile('TestContentObject', '/A/TestNamespace', { English: path.join('test-files', 'TestFile.txt') });
     await editor.main.table.row(0).expectToBeSelected();
-    await editor.main.table.row(0).expectToHaveFileColumns('/A/TestNamespace/TestContentObject', { type: 'FILE', fileExtension: 'txt' }, [true]);
+    await editor.main.table.row(0).expectToHaveFileColumns('FILE', ['/A/TestNamespace/TestContentObject'], ['TestContentObject.txt']);
     await editor.detail.expectToHaveFileValues('/A/TestNamespace/TestContentObject', { English: true, German: false });
   });
 });

--- a/playwright/tests/integration/mock/delete.spec.ts
+++ b/playwright/tests/integration/mock/delete.spec.ts
@@ -26,11 +26,11 @@ test('delete', async () => {
   await firstRow.locator.click();
   await editor.page.keyboard.press('ArrowUp');
   const lastRow = editor.main.table.row(-1);
-  await lastRow.expectToHaveFileColumns('/Files/ImageFile', { type: 'IMAGE', fileExtension: 'png' }, [true]);
+  await lastRow.expectToHaveFileColumns('IMAGE', ['/Files/ImageFile'], ['ImageFile.png']);
   await editor.detail.expectToHaveFileValues('/Files/ImageFile', { English: true, German: false });
   await deleteButton.click();
   await lastRow.expectToBeSelected();
-  await lastRow.expectToHaveFileColumns('/Files/TextFile', { type: 'FILE', fileExtension: 'txt' }, [true]);
+  await lastRow.expectToHaveFileColumns('FILE', ['/Files/TextFile'], ['TextFile.txt']);
   await editor.detail.expectToHaveFileValues('/Files/TextFile', { English: true, German: true });
 });
 

--- a/playwright/tests/integration/mock/detail.spec.ts
+++ b/playwright/tests/integration/mock/detail.spec.ts
@@ -83,14 +83,14 @@ test.describe('delete value', () => {
     await expect(englishValue.fileButton).toBeVisible();
     const fileName = await englishValue.filePicker.evaluate((input: HTMLInputElement) => input.files?.[0]?.name);
     expect(fileName).toEqual('TestFile.txt');
-    await expect(row.column(1).value(0).locator('i')).toBeVisible();
+    await expect(row.column(1).value(0)).toHaveText('TextFile.txt');
 
     await englishValue.delete.click();
 
     await expect(englishValue.fileButton).toBeHidden();
     const fileCount = await englishValue.filePicker.evaluate((input: HTMLInputElement) => input.files?.length);
     expect(fileCount).toEqual(0);
-    await expect(row.column(1).value(0).locator('i')).toBeHidden();
+    await expect(row.column(1).value(0)).toHaveText('');
   });
 });
 

--- a/playwright/tests/integration/mock/main.spec.ts
+++ b/playwright/tests/integration/mock/main.spec.ts
@@ -64,6 +64,6 @@ test('fileValues', async ({ page }) => {
   await editor.main.table.locator.focus();
   await editor.page.keyboard.press('ArrowUp');
 
-  await editor.main.table.row(-1).expectToHaveFileColumns('/Files/ImageFile', { type: 'IMAGE', fileExtension: 'png' }, [true], [false]);
-  await editor.main.table.row(-2).expectToHaveFileColumns('/Files/TextFile', { type: 'FILE', fileExtension: 'txt' }, [true], [true]);
+  await editor.main.table.row(-1).expectToHaveFileColumns('IMAGE', ['/Files/ImageFile'], ['ImageFile.png'], ['']);
+  await editor.main.table.row(-2).expectToHaveFileColumns('FILE', ['/Files/TextFile'], ['TextFile.txt'], ['TextFile.txt']);
 });

--- a/playwright/tests/integration/read.spec.ts
+++ b/playwright/tests/integration/read.spec.ts
@@ -6,7 +6,7 @@ test('load data', async ({ page }) => {
   await expect(editor.main.table.rows).toHaveCount(3);
 
   await editor.main.table.row(0).locator.click();
-  await editor.main.table.row(0).expectToHaveFileColumns('/files/File', { type: 'FILE', fileExtension: 'txt' }, [true]);
+  await editor.main.table.row(0).expectToHaveFileColumns('FILE', ['/files/File'], ['File.txt']);
   await editor.detail.expectToHaveFileValues('/files/File', { English: true, German: false });
 
   await editor.main.table.row(1).locator.click();


### PR DESCRIPTION
- Display an icon in front of each row to indicate the Content Object type and, if applicable, the file type.
- Display the file name, including the file extension, for each language with a value present in the table.